### PR TITLE
fix: use .to_empty() for meta device models during load

### DIFF
--- a/docling_ibm_models/layoutmodel/layout_predictor.py
+++ b/docling_ibm_models/layoutmodel/layout_predictor.py
@@ -89,7 +89,11 @@ class LayoutPredictor:
         self._image_processor = RTDetrImageProcessor.from_json_file(processor_config)
         self._model = RTDetrForObjectDetection.from_pretrained(
             artifact_path, config=model_config
-        ).to(self._device)
+        )
+        if any(p.device.type == "meta" for p in self._model.parameters()):
+            self._model = self._model.to_empty(self._device)
+        else:
+            self._model = self._model.to(self._device)
         self._model.eval()
 
         _log.debug("LayoutPredictor settings: {}".format(self.info()))

--- a/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
@@ -37,7 +37,12 @@ class TableModel04_rs(BaseModel, nn.Module):
         # Encoder
         self._enc_image_size = config["model"]["enc_image_size"]
         self._encoder_dim = config["model"]["hidden_dim"]
-        self._encoder = Encoder04(self._enc_image_size, self._encoder_dim).to(device)
+        self._encoder = Encoder04(self._enc_image_size, self._encoder_dim)
+
+        if any(p.device.type == "meta" for p in self._encoder.parameters()):
+            self._encoder = self._encoder.to_empty(device)
+        else:
+            self._encoder = self._encoder.to(device)
 
         tag_vocab_size = len(word_map["word_map_tag"])
 


### PR DESCRIPTION


Resolves #
 - https://github.com/docling-project/docling/issues/1447
 - #116

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

