### PR TITLE
feat: Refactor the LayoutPredictor to support all layout models

### DIFF
--- a/docling_ibm_models/layoutmodel/labels.py
+++ b/docling_ibm_models/layoutmodel/labels.py
@@ -1,0 +1,53 @@
+from typing import Dict
+
+
+class LayoutLabels:
+    r"""Single point of reference for the layout labels"""
+
+    def __init__(self) -> None:
+        r""" """
+        # Canonical classes originating in DLNv2
+        self._canonical: Dict[int, str] = {
+            # DLNv1 and DLNv2
+            0: "Caption",
+            1: "Footnote",
+            2: "Formula",
+            3: "List-item",
+            4: "Page-footer",
+            5: "Page-header",
+            6: "Picture",
+            7: "Section-header",
+            8: "Table",
+            9: "Text",
+            10: "Title",
+            # DLNv2 only
+            11: "Document Index",
+            12: "Code",
+            13: "Checkbox-Selected",
+            14: "Checkbox-Unselected",
+            15: "Form",
+            16: "Key-Value Region",
+        }
+        self._inverse_canonical: Dict[str, int] = {
+            label: class_id for class_id, label in self._canonical.items()
+        }
+
+        # Shifted canonical classes with background in 0
+        self._shifted_canonical: Dict[int, str] = {0: "Background"}
+        for k, v in self._canonical.items():
+            self._shifted_canonical[k + 1] = v
+        self._inverse_shifted_canonical: Dict[str, int] = {
+            label: class_id for class_id, label in self._shifted_canonical.items()
+        }
+
+    def canonical_categories(self) -> Dict[int, str]:
+        return self._canonical
+
+    def canonical_to_int(self) -> Dict[str, int]:
+        return self._inverse_canonical
+
+    def shifted_canonical_categories(self) -> Dict[int, str]:
+        return self._shifted_canonical
+
+    def shifted_canonical_to_int(self) -> Dict[str, int]:
+        return self._inverse_shifted_canonical

--- a/tests/test_layout_predictor.py
+++ b/tests/test_layout_predictor.py
@@ -4,13 +4,11 @@
 #
 import os
 import json
-from pathlib import Path
 
-import torch
 import numpy as np
 import pytest
 from huggingface_hub import snapshot_download
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image
 
 from docling_ibm_models.layoutmodel.layout_predictor import LayoutPredictor
 
@@ -35,8 +33,7 @@ def init() -> dict:
     }
 
     # Download models from HF
-    download_path = snapshot_download(repo_id="ds4sd/docling-models", revision="v2.1.0")
-    artifact_path = os.path.join(download_path, "model_artifacts/layout")
+    artifact_path = snapshot_download(repo_id="ds4sd/docling-layout-old")
 
     # Add the missing config keys
     init["artifact_path"] = artifact_path


### PR DESCRIPTION
- Refactor the `LayoutPredictor` to support the `RT-DETR`, `RT-DETRv2`, `DFINE` models from the HF transformers implementation.
- Introduce the `LayoutLabels` to have a reference point for all layout labels (with or without shifting).
- Update the `demo_layout_predictor` App.
- Update `test_layout_predictor.py` to download the old layout model from HF.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

