### PR TITLE
fix: table cell alignment regression [bee]

### DIFF
--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -474,9 +474,6 @@ class MatchingPostProcessor:
         pdf_cell_dict = {pdf_cell["id"]: pdf_cell["bbox"] for pdf_cell in pdf_cells}
         table_cell_dict = {cell["cell_id"]: cell for cell in table_cells}
 
-        # Track unique cells we're going to add
-        processed_cells = set()
-
         # First pass - create initial new_table_cells with aligned bboxes
         new_table_cells = []
 
@@ -491,9 +488,6 @@ class MatchingPostProcessor:
 
             # Process each unique table cell
             for cell_id in table_cell_ids:
-                if cell_id in processed_cells:
-                    continue
-
                 table_cell = table_cell_dict.get(cell_id)
                 if not table_cell:
                     continue
@@ -507,7 +501,6 @@ class MatchingPostProcessor:
                     new_table_cell["cell_class"] = "2"
 
                 new_table_cells.append(new_table_cell)
-                processed_cells.add(cell_id)
 
         # Second pass - aggregate bboxes for duplicate cells
         cell_to_bboxes = {}


### PR DESCRIPTION
<!-- Thank you for contributing to docling-ibm-models! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->
Recent changes (between 3.4.1 and 3.4.2) to the table cell processing logic in `align_table_cells_to_pdf`  introduced a regression that causes table text to extend beyond cell boundaries. The code processes each table cell only once, which prevents proper handling of cases where a single table cell should align with multiple PDF cells resulting in cell bounding boxes that are too small to contain their text content. 

examples of failures:
```
# text extends beyond cell bottom boundary
inner_bbox={'b': 382.59, 'l': 56.71, 'r': 71.13, 't': 373.59}
outer_bbox={'b': 372.27, 'l': 56.23, 'r': 71.73, 't': 363.27}

# text extends beyond cell right boundary  
inner_bbox={'b': 251.3, 'l': 487.43, 'r': 530.66, 't': 242.3}
outer_bbox={'b': 240.5, 'l': 487.43, 'r': 523.28, 't': 231.5}
```

The code changes fixes the table cell bounding boxes which should fully contain all text content within the cell. 


<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

