### PR TITLE
Fix RTreeError for elements with floating-point precision issues (Issue #140)

### DIFF
--- a/docling_ibm_models/reading_order/reading_order_rb.py
+++ b/docling_ibm_models/reading_order/reading_order_rb.py
@@ -384,8 +384,10 @@ class ReadingOrderPredictor:
         # Query R-tree for elements between i and j
         x_min = min(pelem_i.l, pelem_j.l) - 1.0
         x_max = max(pelem_i.r, pelem_j.r) + 1.0
-        y_min = pelem_j.t
-        y_max = pelem_i.b
+        # Ensure y_min <= y_max to avoid RTreeError when elements are very close
+        # or have floating-point precision issues
+        y_min = min(pelem_j.t, pelem_i.b)
+        y_max = max(pelem_j.t, pelem_i.b)
 
         candidates = list(spatial_idx.intersection((x_min, y_min, x_max, y_max)))
 


### PR DESCRIPTION
<!-- Thank you for contributing to docling-ibm-models! -->

## Description

This PR fixes an `RTreeError` that occurs when querying the spatial index with elements that are very close together vertically. Due to floating-point precision issues, the calculated `y_min` could be greater than `y_max`, causing the R-tree library to raise an error with the message "Coordinates must not have minimums more than maximums".

The fix ensures that `y_min` and `y_max` are properly ordered by using `min()` and `max()` functions when calculating the bounding box for spatial queries, instead of assuming a specific ordering based on element positions.

**Issue resolved by this Pull Request:**
Resolves #140

## Changes

- Modified `reading_order_rb.py` to use `min()` and `max()` when calculating `y_min` and `y_max` for spatial index queries
- Added comprehensive test cases to verify the fix:
  - `test_close_elements_with_floating_point_precision()`: Tests elements with boundaries that differ by tiny floating-point amounts
  - `test_identical_boundaries()`: Tests edge case where elements have identical vertical boundaries

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.