### PR TITLE
fix: UnboundLocalError in predict_dummy when no bboxes are detected

### DIFF
--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -672,7 +672,10 @@ class TFPredictor:
             "pdf_cells": [],
             "prediction_bboxes_page": [],
         }
-
+        
+        # Initialize TF output
+        tf_output = []
+        
         # Table bbox upscaling will scale predicted bboxes too within cell matcher
         scaled_table_bbox = [
             table_bbox[0] / scale_factor,

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -1033,3 +1033,4 @@ class TFPredictor:
         html_tags = [self._rev_word_map[ind] for ind in seq[1:-1]]
 
         return html_tags
+        

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -672,10 +672,10 @@ class TFPredictor:
             "pdf_cells": [],
             "prediction_bboxes_page": [],
         }
-        
+
         # Initialize TF output
         tf_output = []
-        
+
         # Table bbox upscaling will scale predicted bboxes too within cell matcher
         scaled_table_bbox = [
             table_bbox[0] / scale_factor,
@@ -1033,4 +1033,3 @@ class TFPredictor:
         html_tags = [self._rev_word_map[ind] for ind in seq[1:-1]]
 
         return html_tags
-        


### PR DESCRIPTION
<!-- Thank you for contributing to docling-ibm-models! -->

## Description

This PR fixes an `UnboundLocalError` that occurs in the `predict_dummy` method of `tf_predictor.py` when the model fails to predict any bounding boxes.

Currently, the variable `tf_output` is initialized and assigned only within the `if len(prediction["bboxes"]) > 0:` block. If the model does not populate `prediction["bboxes"]`, this block is skipped, and the subsequent `return tf_output, matching_details` statement raises a "cannot access local variable" error because `tf_output` has not been defined.

The fix initializes `tf_output` as an empty list `[]` prior to the conditional block, ensuring the variable is always defined and the method returns a valid empty result when no predictions are found.

## Changes
- Modified `tf_predictor.py`: Added initialization of `tf_output = []` in `predict_dummy` to handle cases with no predicted bounding boxes.

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [X] Examples have been added, if necessary.
- [X] Tests have been added, if necessary.

