### PR TITLE
fix(matcher): recover orphan pdf cells that match a row band but no column band

### DIFF
--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -896,6 +896,9 @@ class MatchingPostProcessor:
         orphan_columns_bbox = []
         used_col_pdf_ids = []
         used_col_columnid = []
+        # Cache each column's X-centroid so we can fall back to nearest-column
+        # assignment for orphans that match a row band but no column band.
+        col_centroids: dict[int, float] = {}
 
         for col in range(tab_cols):
             bbox_x1s = []  # y2 > y1
@@ -929,6 +932,10 @@ class MatchingPostProcessor:
                 col_x1 = min(bbox_x1s)
             if len(bbox_x2s) > 0:
                 col_x2 = max(bbox_x2s)
+
+            # Cache centroid for nearest-column fallback (see orphan-rows loop).
+            if col_x1 >= 0 and col_x2 >= 0:
+                col_centroids[col] = (col_x1 + col_x2) / 2
 
             # Find "orphan" cells that intersect the band
             for pdf_cell in pdf_cells:
@@ -1050,51 +1057,84 @@ class MatchingPostProcessor:
                 depth_index = orphan_columns[new_column_id].index(pdf_cell_id)
                 confidence = orphan_columns_depth[new_column_id][depth_index]
                 pdf_bbox = orphan_columns_bbox[new_column_id][depth_index]
-
-                # 1. Find table_cell_id by new_row_id / new_column_id
-                new_table_cell_id = -1
-                tcell = list(
-                    filter(
-                        lambda table_cell: table_cell["row_id"] == new_row_id
-                        and table_cell["column_id"] == new_column_id,
-                        table_cells,
-                    )
+            else:
+                # Row-band match but no column-band match. Without the
+                # following fallback the pdf cell is silently dropped (see
+                # https://github.com/docling-project/docling-ibm-models/issues/28
+                # and the symptom in the parent docling issue tracker:
+                # right-aligned values on tables whose predicted columns are
+                # narrower than the page region disappear from the output).
+                # Snap to the nearest column by X-centroid distance and emit
+                # a WARNING so the recovery is observable.
+                pdf_cell = next(
+                    (p for p in pdf_cells if str(p["id"]) == pdf_cell_id),
+                    None,
+                )
+                if pdf_cell is None or not col_centroids:
+                    # Nothing to attach to; preserve historic behaviour.
+                    continue
+                pdf_bbox = pdf_cell["bbox"]
+                cell_cx = (pdf_bbox[0] + pdf_bbox[2]) / 2
+                new_column_id, min_dist = min(
+                    ((c, abs(cell_cx - cx)) for c, cx in col_centroids.items()),
+                    key=lambda t: t[1],
+                )
+                # confidence < 0 marks "nearest-column fallback" so downstream
+                # consumers can distinguish high-confidence band matches from
+                # snapped fallbacks if they care.
+                confidence = -int(round(min_dist)) - 1
+                self._log().warning(
+                    "Orphan pdf_cell %s recovered to col=%s by nearest-column "
+                    "fallback (row=%s, x=%.1f, dist=%.1f)",
+                    pdf_cell_id,
+                    new_column_id,
+                    new_row_id,
+                    cell_cx,
+                    min_dist,
                 )
 
-                if len(tcell) > 0:
-                    new_table_cell_id = tcell[0]["cell_id"]
-                    self._log().debug(
-                        "reusing table_cell_id: {}".format(new_table_cell_id)
-                    )
+            # 1. Find table_cell_id by new_row_id / new_column_id
+            new_table_cell_id = -1
+            tcell = list(
+                filter(
+                    lambda table_cell: table_cell["row_id"] == new_row_id
+                    and table_cell["column_id"] == new_column_id,
+                    table_cells,
+                )
+            )
 
-                    for i in range(len(new_table_cells)):
-                        if new_table_cells[i]["cell_id"] == new_table_cell_id:
-                            bbox_tmp = self._merge_two_bboxes(
-                                new_table_cells[i]["bbox"], pdf_bbox
-                            )
-                            new_table_cells[i]["bbox"] = bbox_tmp
+            if len(tcell) > 0:
+                new_table_cell_id = tcell[0]["cell_id"]
+                self._log().debug("reusing table_cell_id: {}".format(new_table_cell_id))
 
-                if new_table_cell_id < 0:
-                    max_cell_id += 1
-                    new_table_cell_id = max_cell_id
+                for i in range(len(new_table_cells)):
+                    if new_table_cells[i]["cell_id"] == new_table_cell_id:
+                        bbox_tmp = self._merge_two_bboxes(
+                            new_table_cells[i]["bbox"], pdf_bbox
+                        )
+                        new_table_cells[i]["bbox"] = bbox_tmp
 
-                    new_table_cell = {
-                        "bbox": pdf_bbox,
-                        "cell_id": new_table_cell_id,
-                        "column_id": new_column_id,
-                        "label": "body",
-                        "row_id": new_row_id,
-                        "cell_class": 2,
-                    }
-                    self._log().debug(
-                        "making new table_cell_id: {}".format(new_table_cell_id)
-                    )
-                    new_table_cells.append(new_table_cell)
+            if new_table_cell_id < 0:
+                max_cell_id += 1
+                new_table_cell_id = max_cell_id
 
-                # And then add new match to the new_matches
-                new_matches[str(pdf_cell_id)] = [
-                    {"post": confidence, "table_cell_id": new_table_cell_id}
-                ]
+                new_table_cell = {
+                    "bbox": pdf_bbox,
+                    "cell_id": new_table_cell_id,
+                    "column_id": new_column_id,
+                    "label": "body",
+                    "row_id": new_row_id,
+                    "cell_class": 2,
+                }
+                self._log().debug(
+                    "making new table_cell_id: {}".format(new_table_cell_id)
+                )
+                new_table_cells.append(new_table_cell)
+
+            # And then add new match to the new_matches
+            new_matches[str(pdf_cell_id)] = [
+                {"post": confidence, "table_cell_id": new_table_cell_id}
+            ]
         return new_matches, new_table_cells, max_cell_id
 
     def _clear_pdf_cells(self, pdf_cells):

--- a/tests/test_matching_post_processor.py
+++ b/tests/test_matching_post_processor.py
@@ -1,0 +1,108 @@
+"""Unit tests for `MatchingPostProcessor._pick_orphan_cells`.
+
+Specifically the silent-drop case where a PDF text cell falls inside a row
+band but outside every column band: prior to the nearest-column fallback,
+such cells were dropped on the floor without warning. Now they are snapped
+to the closest column by X-centroid distance.
+
+See https://github.com/docling-project/docling-ibm-models/issues/28.
+"""
+
+from docling_ibm_models.tableformer.data_management.matching_post_processor import (
+    MatchingPostProcessor,
+)
+
+
+def _make_proc():
+    # `_pick_orphan_cells` does not exercise the cell matcher; a stub config
+    # is sufficient. CellMatcher init reads `pdf_cell_iou_thres`.
+    return MatchingPostProcessor({"predict": {"pdf_cell_iou_thres": 0.05}})
+
+
+def test_orphan_with_no_col_band_match_is_recovered_to_nearest_column():
+    """A pdf cell inside the row band but outside every column band must
+    still produce a match — historically it was silently dropped."""
+    proc = _make_proc()
+
+    # Two predicted columns whose x-bands lie at x≈10..200, in two rows.
+    # The orphan pdf cell sits in row 1's y-band but its x=560 is outside
+    # both column x-bands — exactly the silent-drop case.
+    table_cells = [
+        {"cell_id": 0, "row_id": 0, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 10, 90, 25]},
+        {"cell_id": 1, "row_id": 0, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 10, 200, 25]},
+        {"cell_id": 2, "row_id": 1, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 30, 90, 45]},
+        {"cell_id": 3, "row_id": 1, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 30, 200, 45]},
+    ]
+    pdf_cells = [
+        # In row 1's y band (30..45) but x=560 — outside col 0 (10..90)
+        # and col 1 (110..200). Pre-fix this gets dropped silently.
+        {"id": 99, "bbox": [550, 32, 590, 43], "text": "$4,129.51"},
+    ]
+    matches: dict = {}  # the orphan is unmatched at entry
+
+    new_matches, new_table_cells, _max_cell_id = proc._pick_orphan_cells(
+        tab_rows=2,
+        tab_cols=2,
+        max_cell_id=3,
+        table_cells=table_cells,
+        pdf_cells=pdf_cells,
+        matches=matches,
+    )
+
+    # After the fix: the orphan must appear in new_matches assigned to a
+    # column (the nearest-centroid one — column 1 at centroid x=155 vs
+    # column 0 at centroid x=50).
+    assert "99" in new_matches, (
+        "orphan pdf_cell was silently dropped (no match emitted)"
+    )
+    assigned = new_matches["99"][0]
+    target_table_cell = next(
+        tc for tc in new_table_cells if tc["cell_id"] == assigned["table_cell_id"]
+    )
+    assert target_table_cell["column_id"] == 1, (
+        f"expected nearest-column fallback to col 1 (centroid 155), "
+        f"got col {target_table_cell['column_id']}"
+    )
+    # confidence is negative for nearest-column fallback.
+    assert assigned["post"] < 0, (
+        f"nearest-column fallback should mark confidence < 0, got {assigned['post']}"
+    )
+
+
+def test_band_matched_orphans_use_normal_path():
+    """The fast-path (orphan inside a column band) must be unchanged."""
+    proc = _make_proc()
+
+    # Two rows of body cells. Orphan pdf cell sits in row 1's y-band AND
+    # within column 0's x-band — the existing happy path.
+    table_cells = [
+        {"cell_id": 0, "row_id": 0, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 10, 90, 25]},
+        {"cell_id": 1, "row_id": 0, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 10, 200, 25]},
+        {"cell_id": 2, "row_id": 1, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 30, 90, 45]},
+        {"cell_id": 3, "row_id": 1, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 30, 200, 45]},
+    ]
+    pdf_cells = [
+        # In col 0's x-band (10..90) AND row 1's y-band (30..45).
+        {"id": 7, "bbox": [20, 32, 80, 43], "text": "in band"},
+    ]
+    matches: dict = {}
+    new_matches, new_table_cells, _ = proc._pick_orphan_cells(
+        tab_rows=2, tab_cols=2, max_cell_id=3,
+        table_cells=table_cells, pdf_cells=pdf_cells, matches=matches,
+    )
+    assert "7" in new_matches
+    assigned = new_matches["7"][0]
+    target = next(tc for tc in new_table_cells if tc["cell_id"] == assigned["table_cell_id"])
+    assert target["column_id"] == 0, "in-band orphan should land in col 0"
+    # Normal-path confidence is non-negative.
+    assert assigned["post"] >= 0, (
+        f"in-band match should have non-negative confidence, got {assigned['post']}"
+    )


### PR DESCRIPTION
## Summary

\`MatchingPostProcessor._pick_orphan_cells\` iterates pdf cells whose y-position falls inside a row band but whose x-position lies outside every predicted column band. The existing code wraps the entire assignment block in \`if pdf_cell_id in used_col_pdf_ids:\` with no \`else\` branch. PDF cells that made it into \`orphan_rows_pdf_ids\` but never landed in a column band are therefore silently dropped — no log, no warning, no fallback.

This shows up in real PDFs as missing data in the output. A representative case: a totals subtable rendered at the bottom of a larger table region where the predicted columns are sized to the upper region's geometry; the right-aligned totals values fall outside every predicted column band and disappear from \`table_cells\` with no observable signal.

## Fix

- Cache each column's X-centroid (\`(col_x1 + col_x2) / 2\`) once during the per-column orphan loop in a new \`col_centroids: dict[int, float]\` keyed by column id.
- Add an \`else\` branch in the orphan-rows loop: when a pdf cell has a row-band match but no column-band match, snap to the column whose centroid is nearest the pdf cell's X-centroid.
- Confidence is encoded as \`-int(round(distance)) - 1\` so fallback matches are always negative; downstream consumers can distinguish them from band matches if they care.
- Emit a \`WARNING\`-level log so the recovery is observable. The function only logs at DEBUG today — operators reasonably expect a WARNING when the matcher resorts to a fallback path.
- Hoist the cell-create / reuse / \`new_matches[...]\` block out of the \`if\` so both paths share it. No behavioural change to the happy path (in-band orphans).

## What this does *not* fix

There is an orthogonal silent-drop pathway where a pdf cell's y-position is just outside every row band (the row-band detection at lines 828-838 has the same inclusive-boundary issue). I encountered this on real-world Computershare dividend statements where a totals data row sits ~3 page units below the predicted row band's bottom edge, so the values never make it into \`orphan_rows_pdf_ids\` for my fix to recover. Addressing that requires either a complementary fallback for cells inside the table prov bbox but outside all row bands, or a relaxation of the row-band inclusion bounds. Tracking as follow-up.

## Test plan

- [x] New \`tests/test_matching_post_processor.py\`:
  - \`test_orphan_with_no_col_band_match_is_recovered_to_nearest_column\` — synthetic input where a pdf cell sits in a row's y-band but x=560 (outside both column x-bands at 10..90 and 110..200). Pre-fix the orphan is dropped from \`new_matches\`; post-fix it is assigned to the nearest column (col 1, centroid 155, dist 405) and confidence < 0.
  - \`test_band_matched_orphans_use_normal_path\` — sanity check that in-band orphans take the unchanged happy path with confidence >= 0.
- [x] \`pre-commit run --files <changed-files>\` — Black, isort, MyPy all green after autoformat.
- [x] End-to-end smoke test on a real Computershare dividend PDF with a totals subtable: WARNING fires for the orphan pdf cell, the recovered cell appears in \`table_cells\` for row 21 of the table.
- [x] Existing test suite unaffected: light tests pass; integration tests (\`test_tf_predictor.py\`, \`test_tableformer_v2.py\`) not run locally — they require model weights — but no behaviour change in the in-band fast path means they should remain green.

## Issues addressed

Closes #28 (partially) — "Post processing improvements". The reporter asked for orphan tokens to be assigned rather than dropped. This addresses the column-band-miss case. The row-band-miss case is documented as follow-up above.

## Notes

- \`tab_cols\`, \`pdf_cells\`, etc. are the existing function parameters; no signature change.
- No new dependencies.
- The change is purely additive to behaviour: orphans previously dropped now land in some column. The change cannot remove cells that were previously emitted, only add cells. Worst case is over-eager attachment of a stray pdf token to a column, which the WARNING log makes immediately visible in operator output.