### PR TITLE
perf:  Cache loggers in get_custom_logger to avoid redundant setLevel() calls

### DIFF
--- a/docling_ibm_models/tableformer/settings.py
+++ b/docling_ibm_models/tableformer/settings.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+_loggers_by_name_and_level = {}
+
 
 def get_custom_logger(logger_name, level, stream=sys.stdout):
     r"""
@@ -14,6 +16,11 @@ def get_custom_logger(logger_name, level, stream=sys.stdout):
     Outputs:
         logger
     """
+    cache_key = (logger_name, level)
+    cached_logger = _loggers_by_name_and_level.get(cache_key)
+    if cached_logger is not None:
+        return cached_logger
+
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
 
@@ -26,6 +33,7 @@ def get_custom_logger(logger_name, level, stream=sys.stdout):
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
+    _loggers_by_name_and_level[cache_key] = logger
     return logger
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to docling-ibm-models! -->

I found this issue when looking for performance improvements.

It appears that get_custom_logger() calls logger.setLevel() every time it runs, even when it is called repeatedly with the same logger name and the same level. But Logger.setLevel() always invalidates the whole logging module's internal cache, no matter whether the level actually changed.

That is fine if the function is called occasionally, but several classes in this package (for example MatchingPostProcessor) call it fresh on every single log line instead of storing the logger once. 

I discovered on a real 406-page PDF with 81 tables, that this adds up to about *3.9 million* calls to get_custom_logger(), and hence Logger.setLevel, and hence 3.9m cache invalidations, during table-cell matching alone (!!). 

This can all be avoided with a simple dict cache, keyed by name and level. A repeat call with the same name and level returns the cached logger straight away, without pointlessly calling setLevel() again. A call with a genuinely different level still updates the logger as before, so behaviour is unchanged for any caller that actually needs to change the level.

After the patch the same 406-page test document took about 104 secs to process, down from 210 before.

No changes to the documentation seem necessary to me, but let me know if you disagree.
