### PR TITLE
fix(matcher): report pdf cells dropped for matching no row band (#172)

### DIFF
--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -776,6 +776,16 @@ class MatchingPostProcessor:
         new_matches = matches
         new_table_cells = table_cells
 
+        # new_matches aliases matches and grows below, so the orphans have to be
+        # collected before that. A pdf cell only reaches a table cell if it ends
+        # up keyed here; anything left over at the end of step 9 is dropped from
+        # the table for good, and used to be dropped without a trace.
+        orphan_pdf_ids = {
+            str(pdf_cell["id"])
+            for pdf_cell in pdf_cells
+            if str(pdf_cell["id"]) not in matches
+        }
+
         # Identify orphan rows (START)
         orphan_rows = []
         orphan_rows_depth = []
@@ -1095,6 +1105,23 @@ class MatchingPostProcessor:
                 new_matches[str(pdf_cell_id)] = [
                     {"post": confidence, "table_cell_id": new_table_cell_id}
                 ]
+
+        # Step 9 only rescues an orphan that intersects a row band; one that
+        # matches no band at all never enters the loop above and is discarded.
+        # That is a real content loss (its text is in no table cell, and the
+        # layout cluster already claimed it), so say so instead of failing
+        # silently -- callers have no other way to notice.
+        unassigned_pdf_ids = orphan_pdf_ids.difference(new_matches)
+        if unassigned_pdf_ids:
+            self._log().warning(
+                "{} of {} pdf cells matched no row band of the {}x{} grid and "
+                "were dropped from the table".format(
+                    len(unassigned_pdf_ids), len(pdf_cells), tab_rows, tab_cols
+                )
+            )
+            self._log().debug(
+                "Dropped pdf cell ids: {}".format(sorted(unassigned_pdf_ids))
+            )
         return new_matches, new_table_cells, max_cell_id
 
     def _clear_pdf_cells(self, pdf_cells):

--- a/tests/test_matching_post_processor_orphans.py
+++ b/tests/test_matching_post_processor_orphans.py
@@ -1,0 +1,94 @@
+import logging
+
+import pytest
+
+from docling_ibm_models.tableformer.data_management.matching_post_processor import (
+    MatchingPostProcessor,
+)
+
+
+def _processor() -> MatchingPostProcessor:
+    return MatchingPostProcessor({"predict": {"pdf_cell_iou_thres": 0.05}})
+
+
+@pytest.fixture
+def captured_logs():
+    """Collect what MatchingPostProcessor logs, whatever handlers it installs."""
+    records: list[tuple[str, str]] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append((record.levelname, record.getMessage()))
+
+    logger = logging.getLogger(MatchingPostProcessor.__name__)
+    handler = _Collector()
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_orphan_cells_outside_every_row_band_are_reported(captured_logs):
+    """Step 9 only rescues an orphan that intersects a row band.
+
+    A pdf cell matching no band at all is discarded, and the layout cluster has
+    already claimed its text, so it vanishes from the document. That used to
+    happen with no log, no warning and no counter.
+    """
+    table_cells = [
+        {
+            "cell_id": 0,
+            "row_id": 0,
+            "column_id": 0,
+            "bbox": [0, 0, 50, 20],
+            "cell_class": 2,
+            "label": "body",
+        },
+    ]
+    # Two of the three pdf cells sit far below the only row band (y in [0, 20]).
+    pdf_cells = [
+        {"id": 0, "bbox": [0, 0, 50, 20], "text": "inside the grid"},
+        {"id": 1, "bbox": [0, 200, 50, 220], "text": "below the grid"},
+        {"id": 2, "bbox": [0, 300, 50, 320], "text": "also below the grid"},
+    ]
+    matches = {"0": [{"iou": 0.9, "table_cell_id": 0}]}
+
+    new_matches, _, _ = _processor()._pick_orphan_cells(
+        1, 1, 0, table_cells, pdf_cells, matches
+    )
+
+    # The drop itself is unchanged -- this is about making it observable.
+    assert sorted(new_matches) == ["0"]
+
+    warnings = [message for level, message in captured_logs if level == "WARNING"]
+    assert warnings == [
+        "2 of 3 pdf cells matched no row band of the 1x1 grid and "
+        "were dropped from the table"
+    ]
+
+
+def test_no_warning_when_every_orphan_is_assigned(captured_logs):
+    """An orphan inside the band is rescued as before, so nothing is reported."""
+    table_cells = [
+        {
+            "cell_id": 0,
+            "row_id": 0,
+            "column_id": 0,
+            "bbox": [0, 0, 50, 20],
+            "cell_class": 2,
+            "label": "body",
+        },
+    ]
+    pdf_cells = [
+        {"id": 0, "bbox": [0, 0, 50, 20], "text": "matched"},
+        {"id": 1, "bbox": [0, 5, 50, 18], "text": "orphan inside the band"},
+    ]
+    matches = {"0": [{"iou": 0.9, "table_cell_id": 0}]}
+
+    new_matches, _, _ = _processor()._pick_orphan_cells(
+        1, 1, 0, table_cells, pdf_cells, matches
+    )
+
+    assert sorted(new_matches) == ["0", "1"]
+    assert [message for level, message in captured_logs if level == "WARNING"] == []


### PR DESCRIPTION
Closes the observability half of #172.

### The drop

Step 9 (`_pick_orphan_cells`) rescues an orphan pdf cell by first collecting the cells that intersect a **row** band, then looking up a column for each of them. A cell that intersects no row band never makes it into `orphan_rows_pdf_ids`, so it never reaches that loop — it is discarded with no log, no warning and no counter. #159 handles the neighbouring "row band but no column band" case; this is the case where *neither* band matches, which happens when the predicted grid is much smaller than the layout cluster that fed it.

The loss is invisible from the outside: the layout model has already assigned those cells to the `table` cluster, so they do not reappear as body text either. The reporter measured 280 words lost across a 24-PDF corpus (up to 37.7% of the words inside a single table) and describes it as a two-day investigation that a log line would have ended.

### The change

`_pick_orphan_cells` snapshots the orphan ids up front — it has to, because `new_matches` aliases `matches` and grows as cells are assigned — and after step 9 warns with how many pdf cells were never assigned, plus the grid dimensions they were matched against. The ids themselves go to `debug` so the warning stays one line per table.

```
WARNING  MatchingPostProcessor: 2 of 3 pdf cells matched no row band of the 1x1 grid and were dropped from the table
```

**Nothing is rescued that was not rescued before**, so extraction output is byte-for-byte unchanged; this only makes the existing drop visible. The fallback the issue also asks for (snap-to-nearest row/column, or emit an extra row) changes what the table contains and is deliberately **not** in this PR — that needs a maintainer call on which behaviour is wanted, and it overlaps with #159's approach.

### Verification

Ran against `pip install docling-ibm-models==3.13.3`, which is byte-identical to `main` for this module, so the tests exercise the real code path:

- `test_orphan_cells_outside_every_row_band_are_reported` — 1×1 grid, two pdf cells far below the only row band. **Fails on `main`** (no warning is emitted at all), passes here, and asserts `new_matches` is unchanged so the fix stays observation-only.
- `test_no_warning_when_every_orphan_is_assigned` — an orphan *inside* the band is still rescued and nothing is logged, so the warning cannot fire spuriously. Passes both before and after.

Tests live in a new `tests/test_matching_post_processor_orphans.py` rather than in the `tests/test_matching_post_processor.py` that #159 introduces, so the two PRs do not collide.

`black~=24.4` and `isort --profile black` are clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
