### PR TITLE
fix(tableformer): remap end row/col offsets when compressing indexes (#123)

### DIFF
--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import threading
+from bisect import bisect_left
 from itertools import groupby
 from pathlib import Path
 
@@ -459,6 +460,63 @@ class TFPredictor:
         # return the resized image
         return resized, sf
 
+    @staticmethod
+    def _compress_row_col_indexes(tf_responses):
+        r"""
+        Renumber the row/column offsets of the matched cells so that they are
+        sequential and without gaps.
+
+        The IDs carried by the matched cells come from the CellMatcher, not from
+        TableFormer, and they do contain gaps: a row or column made up entirely
+        of empty cells has all of its cells discarded during matching, so no cell
+        starts there anymore. Both ends of a cell are therefore mapped through
+        the same table of surviving IDs -- computing the end offset as
+        "start + span" instead would count the discarded rows/columns that a
+        spanning cell crosses, and push the end offset (and the span) past the
+        real number of rows/columns.
+
+        Parameters
+        ----------
+        tf_responses : list of dict
+            Matched cells, updated in place.
+
+        Returns
+        -------
+        (int, int)
+            The number of columns and rows after the renumbering.
+        """
+        # Collect the surviving col/row IDs, which double as the new indexes.
+        start_cols = sorted({cell["start_col_offset_idx"] for cell in tf_responses})
+        start_rows = sorted({cell["start_row_offset_idx"] for cell in tf_responses})
+
+        num_cols = 0
+        num_rows = 0
+        # After this - put actual indexes of IDs back into predicted structure...
+        for tf_response_cell in tf_responses:
+            start_col_id = tf_response_cell["start_col_offset_idx"]
+            start_row_id = tf_response_cell["start_row_offset_idx"]
+            # The end offset is exclusive, so bisect_left gives the number of
+            # surviving cols/rows that precede it.
+            end_col_offset_idx = bisect_left(
+                start_cols, start_col_id + tf_response_cell["col_span"]
+            )
+            end_row_offset_idx = bisect_left(
+                start_rows, start_row_id + tf_response_cell["row_span"]
+            )
+            start_col_offset_idx = bisect_left(start_cols, start_col_id)
+            start_row_offset_idx = bisect_left(start_rows, start_row_id)
+
+            tf_response_cell["start_col_offset_idx"] = start_col_offset_idx
+            tf_response_cell["end_col_offset_idx"] = end_col_offset_idx
+            tf_response_cell["col_span"] = end_col_offset_idx - start_col_offset_idx
+            tf_response_cell["start_row_offset_idx"] = start_row_offset_idx
+            tf_response_cell["end_row_offset_idx"] = end_row_offset_idx
+            tf_response_cell["row_span"] = end_row_offset_idx - start_row_offset_idx
+
+            num_cols = max(num_cols, end_col_offset_idx)
+            num_rows = max(num_rows, end_row_offset_idx)
+        return num_cols, num_rows
+
     def multi_table_predict(
         self,
         iocr_page,
@@ -505,62 +563,10 @@ class TFPredictor:
             # Indexes should be in increasing order, without gaps
 
             if sort_row_col_indexes:
-                # Fix col/row indexes
-                # Arranges all col/row indexes sequentially without gaps using input IDs
-
-                indexing_start_cols = (
-                    []
-                )  # Index of original start col IDs (not indexes)
-                indexing_start_rows = (
-                    []
-                )  # Index of original start row IDs (not indexes)
-
-                # First, collect all possible predicted IDs, to be used as indexes
-                # ID's returned by Tableformer are sequential, but might contain gaps
-                for tf_response_cell in tf_responses:
-                    start_col_offset_idx = tf_response_cell["start_col_offset_idx"]
-                    start_row_offset_idx = tf_response_cell["start_row_offset_idx"]
-
-                    # Collect all possible col/row IDs:
-                    if start_col_offset_idx not in indexing_start_cols:
-                        indexing_start_cols.append(start_col_offset_idx)
-                    if start_row_offset_idx not in indexing_start_rows:
-                        indexing_start_rows.append(start_row_offset_idx)
-
-                indexing_start_cols.sort()
-                indexing_start_rows.sort()
-
-                max_end_col_idx = 0
-                max_end_row_idx = 0
-                # After this - put actual indexes of IDs back into predicted structure...
-                for tf_response_cell in tf_responses:
-                    tf_response_cell["start_col_offset_idx"] = (
-                        indexing_start_cols.index(
-                            tf_response_cell["start_col_offset_idx"]
-                        )
-                    )
-                    tf_response_cell["end_col_offset_idx"] = (
-                        tf_response_cell["start_col_offset_idx"]
-                        + tf_response_cell["col_span"]
-                    )
-                    max_end_col_idx = max(
-                        max_end_col_idx, tf_response_cell["end_col_offset_idx"]
-                    )
-                    tf_response_cell["start_row_offset_idx"] = (
-                        indexing_start_rows.index(
-                            tf_response_cell["start_row_offset_idx"]
-                        )
-                    )
-                    tf_response_cell["end_row_offset_idx"] = (
-                        tf_response_cell["start_row_offset_idx"]
-                        + tf_response_cell["row_span"]
-                    )
-                    max_end_row_idx = max(
-                        max_end_row_idx, tf_response_cell["end_row_offset_idx"]
-                    )
+                num_cols, num_rows = self._compress_row_col_indexes(tf_responses)
                 # Counting matched cols/rows from actual indexes (and not ids)
-                predict_details["num_cols"] = max_end_col_idx
-                predict_details["num_rows"] = max_end_row_idx
+                predict_details["num_cols"] = num_cols
+                predict_details["num_rows"] = num_rows
             else:
                 otsl_seq = predict_details["prediction"]["rs_seq"]
                 predict_details["num_cols"] = otsl_seq.index("nl")

--- a/tests/test_tf_predictor_indexes.py
+++ b/tests/test_tf_predictor_indexes.py
@@ -1,0 +1,86 @@
+import pytest
+
+from docling_ibm_models.tableformer.data_management.tf_predictor import TFPredictor
+
+
+def _cell(start_col, start_row, col_span=1, row_span=1):
+    return {
+        "start_col_offset_idx": start_col,
+        "start_row_offset_idx": start_row,
+        "col_span": col_span,
+        "row_span": row_span,
+    }
+
+
+def _issue_123_cells():
+    r"""
+    The table reported in docling-ibm-models#123.
+
+    TableFormer predicts 6 columns and 7 rows. Column ID 4 is covered by a
+    single empty "ched" that starts on row 1 and spans the remaining 6 rows;
+    the CellMatcher drops it (and its "ucel" continuations) because it has no
+    text, so no cell starts at column ID 4 anymore. The header on row 0 spans
+    all 6 predicted columns.
+    """
+    cells = [_cell(0, 0, col_span=6)]
+    for col in (0, 1, 2, 3, 5):
+        cells.append(_cell(col, 1))
+    for row in range(2, 7):
+        for col in (0, 1, 2, 3, 5):
+            cells.append(_cell(col, row))
+    return cells
+
+
+def test_compress_row_col_indexes_does_not_count_dropped_columns():
+    cells = _issue_123_cells()
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    # Column ID 4 held only empty cells, so the table has 5 columns, not 6.
+    assert num_cols == 5
+    assert num_rows == 7
+
+    header = cells[0]
+    assert header["start_col_offset_idx"] == 0
+    assert header["end_col_offset_idx"] == 5
+    assert header["col_span"] == 5
+
+    # No cell may point past the compressed table.
+    for cell in cells:
+        assert cell["end_col_offset_idx"] <= num_cols
+        assert cell["end_row_offset_idx"] <= num_rows
+
+
+def test_compress_row_col_indexes_does_not_count_dropped_rows():
+    r"""Same defect on the row axis: row ID 2 has no surviving cell."""
+    cells = [_cell(0, 0, row_span=4), _cell(1, 0), _cell(1, 1), _cell(1, 3)]
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    assert num_cols == 2
+    assert num_rows == 3
+
+    spanning = cells[0]
+    assert spanning["start_row_offset_idx"] == 0
+    assert spanning["end_row_offset_idx"] == 3
+    assert spanning["row_span"] == 3
+
+
+@pytest.mark.parametrize("col_span", [1, 2, 3])
+@pytest.mark.parametrize("row_span", [1, 2, 3])
+def test_compress_row_col_indexes_keeps_gap_free_tables_intact(col_span, row_span):
+    r"""A table without dropped rows/columns must survive unchanged."""
+    cells = [_cell(col, row) for col in range(3) for row in range(3)]
+    cells[0]["col_span"] = col_span
+    cells[0]["row_span"] = row_span
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    assert (num_cols, num_rows) == (3, 3)
+    for cell in cells:
+        assert cell["end_col_offset_idx"] == (
+            cell["start_col_offset_idx"] + cell["col_span"]
+        )
+        assert cell["end_row_offset_idx"] == (
+            cell["start_row_offset_idx"] + cell["row_span"]
+        )


### PR DESCRIPTION
## Summary

Fixes #123.

`multi_table_predict(sort_row_col_indexes=True)` renumbers the matched cells so that
their row/column offsets are sequential and without gaps. It collects the surviving
**start** IDs into a mapping table, but then recomputes each end offset as
`new start + span`, reusing the span that was measured in the *original* ID space:

```python
tf_response_cell["start_col_offset_idx"] = indexing_start_cols.index(
    tf_response_cell["start_col_offset_idx"]
)
tf_response_cell["end_col_offset_idx"] = (
    tf_response_cell["start_col_offset_idx"] + tf_response_cell["col_span"]
)
```

As the issue points out, the comment above that block ("ID's returned by Tableformer
are sequential, but might contain gaps") is misleading: the IDs come from the
`CellMatcher`, and they contain gaps precisely because a row or column made up
entirely of empty cells has all of its cells discarded during matching, so nothing
starts there anymore. A cell that *spans* such a row/column keeps a span that still
counts the discarded row/column, so its end offset — and `num_cols` / `num_rows` —
point past the real size of the compressed table.

## Fix

Map **both** ends through the same table of surviving IDs (`bisect_left`, since the
end offset is exclusive and the end ID itself may have been dropped), and derive the
span from the remapped offsets so the cell stays self-consistent. The renumbering
logic moves into a `TFPredictor._compress_row_col_indexes` static method so it can be
tested without running the model.

## Effect

On the table from the issue (6 predicted columns × 7 rows, where column ID 4 holds a
single empty 6-row `ched` that matching drops):

| | `num_cols` | row-0 header `end_col_offset_idx` | its `col_span` |
|---|---|---|---|
| before | 6 | 6 | 6 |
| after | **5** | **5** | **5** |

Before the fix the header claims a 6th column that no longer exists in the output.

## Verification

`docling_ibm_models` 3.13.3 on PyPI is byte-identical to this file on `main`, so the
released wheel doubles as a harness. Replaying the old inline block and the new helper
over the issue's table reproduces the table above, and over every gap-free grid
(1–4 columns × 1–4 rows, every span combination) the two agree on all four offsets —
tables without dropped rows/columns are renumbered exactly as before.

The three new tests in `tests/test_tf_predictor_indexes.py` (11 cases with the
parametrization) pass against the patched package and fail against `main`. They need
no model download.

`black` (24.x, the pinned pre-commit hook) reports the file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
