### PR TITLE
fix(tf_cell_matcher): correct the vertical non-overlap check in find_intersection (#142)

### DIFF
--- a/docling_ibm_models/tableformer/data_management/tf_cell_matcher.py
+++ b/docling_ibm_models/tableformer/data_management/tf_cell_matcher.py
@@ -65,7 +65,7 @@ def find_intersection(b1, b2):
     The bbox of the intersection or None if there is no intersection
     """
     # Check when the bboxes do NOT intersect
-    if b1[2] < b2[0] or b2[2] < b1[0] or b1[1] > b2[3] or b2[1] > b2[3]:
+    if b1[2] < b2[0] or b2[2] < b1[0] or b1[1] > b2[3] or b2[1] > b1[3]:
         return None
 
     i_bbox = [

--- a/tests/test_tf_cell_matcher.py
+++ b/tests/test_tf_cell_matcher.py
@@ -1,0 +1,27 @@
+from docling_ibm_models.tableformer.data_management.tf_cell_matcher import (
+    find_intersection,
+)
+
+
+def test_find_intersection_overlapping():
+    # Two overlapping bboxes ([x1, y1, x2, y2], y1 <= y2) share a rectangle.
+    b1 = [0, 0, 10, 10]
+    b2 = [5, 5, 15, 15]
+    assert find_intersection(b1, b2) == [5, 5, 10, 10]
+
+
+def test_find_intersection_disjoint_horizontally():
+    # b2 sits entirely to the right of b1.
+    assert find_intersection([0, 0, 10, 10], [20, 0, 30, 10]) is None
+    # b2 sits entirely to the left of b1.
+    assert find_intersection([20, 0, 30, 10], [0, 0, 10, 10]) is None
+
+
+def test_find_intersection_disjoint_vertically():
+    # b1 sits entirely below b2 (in bbox coordinates, b1[1] > b2[3]).
+    assert find_intersection([0, 20, 10, 30], [0, 0, 10, 10]) is None
+    # b2 sits entirely below b1 (b2[1] > b1[3]).  This is the case the buggy
+    # ``b2[1] > b2[3]`` check missed: it never fired for a well-formed box, so
+    # find_intersection returned a degenerate, y-inverted rectangle instead of
+    # None.
+    assert find_intersection([0, 0, 10, 10], [0, 20, 10, 30]) is None


### PR DESCRIPTION
### Problem

In `find_intersection` (`docling_ibm_models/tableformer/data_management/tf_cell_matcher.py`), the fast-reject "no intersection" check reads:

```python
if b1[2] < b2[0] or b2[2] < b1[0] or b1[1] > b2[3] or b2[1] > b2[3]:
    return None
```

The last term `b2[1] > b2[3]` compares **b2's own** `y_min` against **b2's own** `y_max`. For any well-formed bbox (`y1 <= y2`, which holds in both the page and table coordinate systems documented in this module) that term is never true. It was clearly meant to be the symmetric partner of `b1[1] > b2[3]`, i.e. the "b2 lies entirely above b1" case: `b2[1] > b1[3]`.

Because of this, when `b2` sits entirely above `b1` (`b2[1] > b1[3]`) the function does **not** return `None`; it falls through and builds

```python
[max(b1[0], b2[0]), max(b1[1], b2[1]), min(b1[2], b2[2]), min(b1[3], b2[3])]
```

which yields a degenerate, y-inverted rectangle (`y_min > y_max`) instead of `None`, corrupting the downstream PDF-cell ↔ table-cell matching in `CellMatcher`.

### Fix

Replace the term with `b2[1] > b1[3]` so the vertical check is symmetric with the existing `b1[1] > b2[3]` term. This is the minimal change and matches the coordinate convention used by the rest of the function.

### Tests

Adds `tests/test_tf_cell_matcher.py` covering the overlapping case and all four disjoint orientations. The new "b2 entirely above b1" assertion fails on the old code (it returned `[0, 20, 10, 10]`) and passes with the fix.

Fixes #142. Thanks to @ddoron9 for the precise analysis in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
