### PR TITLE
fix(deps): exclude transformers 5.13.0, which breaks the image-processor registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dependencies = [
   'docling-core (>=2.19.0,<3.0.0)',
   # temporary solution until huggingface/transformers#46159 is resolved
   'transformers (>=4.42.0,<5.9.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*) ; sys_platform == "darwin"',
-  'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*) ; sys_platform != "darwin"',
+  # transformers 5.13.0 breaks AutoImageProcessor.register() with a string config_class
+  # (fixed upstream in huggingface/transformers#47148, shipped in 5.13.1); see #167
+  'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0) ; sys_platform != "darwin"',
   'numpy (>=1.24.4,<3.0.0)',
   "rtree>=1.0.0",
   'accelerate (>=1.2.1,<2.0.0)',

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.2.2,<3.0.0" },
     { name = "torchvision", specifier = ">=0,<1" },
     { name = "tqdm", specifier = ">=4.64.0,<5.0.0" },
-    { name = "transformers", marker = "sys_platform != 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,<6.0.0" },
+    { name = "transformers", marker = "sys_platform != 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0,<6.0.0" },
     { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,<5.9.0" },
 ]
 provides-extras = ["opencv-python-headless", "opencv-python"]


### PR DESCRIPTION
Fixes #167.

### Problem

`docling_ibm_models/code_formula_model/models/sam_opt_image_processor.py` registers its processor with a **string** `config_class`:

```python
AutoImageProcessor.register(
    config_class="SamOptImageProcessor",
    slow_image_processor_class=SamOptImageProcessor,
)
```

transformers 5.13.0 added a remote-code guard to `_LazyAutoMapping.register` that dereferences the key's module without a guard:

```python
if key.__module__.startswith("transformers."):   # 5.13.0
    return
```

A string key has no `__module__`, so importing `CodeFormulaPredictor` raises at module import time:

```
AttributeError: 'str' object has no attribute '__module__'
```

### Why only 5.13.0

Upstream fixed this in huggingface/transformers#47148 (`getattr(key, "__module__", "")`), merged 2026-07-08 and shipped in **5.13.1** (2026-07-11). Releases before 5.13.0 have no such guard at all. So 5.13.0 is the single affected release — excluding the whole `5.13.*` series would needlessly rule out a working 5.13.1.

Verified against real installs (torch 2.13.0+cpu), running the same `register()` call as the repo:

| transformers | `AutoImageProcessor.register(config_class="SamOptImageProcessor", ...)` |
|---|---|
| 5.12.1 | OK |
| **5.13.0** | **`AttributeError: 'str' object has no attribute '__module__'`** |
| 5.13.1 | OK |
| 5.15.0 | OK |

### Change

Per @cau-git's guidance on #168 ("we would add transformers 5.13 to an exception list in the pyproject.toml such that this version isn't picked"), this pins the exclusion in metadata rather than working around it in code:

```diff
-'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*) ; sys_platform != "darwin"',
+'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0) ; sys_platform != "darwin"',
```

The darwin constraint already caps at `<5.9.0`, so 5.13.0 was never reachable there and that line is left untouched.

`uv.lock` is regenerated with `uv lock` (`uv lock --check` passes). The resolved transformers version stays **5.8.1** — only the recorded requirement string changes, so no dependency actually moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
