### PR TITLE
fix(logging): name the module loggers after their modules (#127)

### DIFF
--- a/docling_ibm_models/tableformer/common.py
+++ b/docling_ibm_models/tableformer/common.py
@@ -9,7 +9,7 @@ import docling_ibm_models.tableformer.settings as s
 from docling_ibm_models.tableformer.models.common.base_model import BaseModel
 
 LOG_LEVEL = logging.DEBUG
-logger = s.get_custom_logger("common", LOG_LEVEL)
+logger = s.get_custom_logger(__name__, LOG_LEVEL)
 
 
 def validate_config(config):

--- a/docling_ibm_models/tableformer/otsl.py
+++ b/docling_ibm_models/tableformer/otsl.py
@@ -6,7 +6,7 @@ import docling_ibm_models.tableformer.settings as s
 
 LOG_LEVEL = logging.INFO
 # LOG_LEVEL = logging.DEBUG
-logger = s.get_custom_logger("consolidate", LOG_LEVEL)
+logger = s.get_custom_logger(__name__, LOG_LEVEL)
 # png_files = {}  # Evaluation files
 total_pics = 0
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import tempfile
 
 import docling_ibm_models.tableformer.common as c
+import docling_ibm_models.tableformer.otsl as otsl
 
 
 test_config_a = {
@@ -83,3 +85,19 @@ def test_read_config():
         # Read the tmp file and extract the config
         config = c.read_config(fp.name)
         assert isinstance(config, dict)
+
+
+def test_module_loggers_are_namespaced():
+    r"""
+    Module-level loggers must be named after the module that owns them.
+
+    `get_custom_logger` calls `setLevel` on whatever name it is handed, so a
+    bare name reconfigures the importing application's logger of the same name.
+    """
+    for name in ("common", "consolidate"):
+        assert logging.getLogger(name).level == logging.NOTSET, (
+            f"importing docling_ibm_models set a level on the '{name}' logger"
+        )
+
+    assert c.logger.name == "docling_ibm_models.tableformer.common"
+    assert otsl.logger.name == "docling_ibm_models.tableformer.otsl"


### PR DESCRIPTION
Fixes #127.

### The problem

`get_custom_logger(name, level)` does `logging.getLogger(name).setLevel(level)`. Two module-level loggers passed a **bare** name rather than `__name__`:

| file | name passed | level forced |
|---|---|---|
| `docling_ibm_models/tableformer/common.py:12` | `"common"` | `DEBUG` |
| `docling_ibm_models/tableformer/otsl.py:9` | `"consolidate"` | `INFO` |

Those are top-level logger names this package does not own. An application that has its own `common` module — and so its own `logging.getLogger("common")` — gets that logger silently switched to `DEBUG` the moment `docling_ibm_models` is imported, which is exactly what #127 reports. `"consolidate"` is the same defect one level quieter.

### The fix

Pass `__name__`, as `tableformer/data_management/tf_predictor.py:33` already does, so the level lands on `docling_ibm_models.tableformer.common` / `...otsl`.

**What is deliberately left alone:** the seven `get_custom_logger(self.__class__.__name__, LOG_LEVEL)` calls. Per-class logger names are the convention `settings.py` documents ("It is encouraged that each class has it's own custom logger with the name of the class"), and renaming them would move logger names downstream users may already configure. The three module-level call sites are the whole set considered here, and `tf_predictor.py` was already correct.

Levels are unchanged — `common.py` keeps `LOG_LEVEL = logging.DEBUG`, `otsl.py` keeps `logging.INFO`. Only the name they are applied to changes.

### Verification

Added `test_module_loggers_are_namespaced` to `tests/test_common.py`: it asserts the foreign `common` / `consolidate` loggers are still at `NOTSET` after import, and that both module loggers carry their dotted module names.

```
before:  1 failed, 3 passed   (AssertionError: <Logger common (DEBUG)> ... and 0 = logging.NOTSET)
after:   4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
