### PR TITLE
fix(list_item_normalizer): keep multi-line list item text (#179)

### DIFF
--- a/docling_ibm_models/list_item_normalizer/list_marker_processor.py
+++ b/docling_ibm_models/list_item_normalizer/list_marker_processor.py
@@ -71,11 +71,15 @@ class ListItemMarkerProcessor:
             re.compile(f"^{pattern}$") for pattern in self._numbered_patterns
         ]
 
+        # re.DOTALL so the content group spans the whole item: page backends emit
+        # newlines inside a single item's text, and without it the text would be
+        # silently cut at the first one.
         self._compiled_bullet_item_patterns = [
-            re.compile(f"^({pattern})" + r"\s(.+)") for pattern in self._bullet_patterns
+            re.compile(f"^({pattern})" + r"\s(.+)", re.DOTALL)
+            for pattern in self._bullet_patterns
         ]
         self._compiled_numbered_item_patterns = [
-            re.compile(f"^({pattern})" + r"\s(.+)")
+            re.compile(f"^({pattern})" + r"\s(.+)", re.DOTALL)
             for pattern in self._numbered_patterns
         ]
 

--- a/tests/test_listitem_marker_model.py
+++ b/tests/test_listitem_marker_model.py
@@ -154,3 +154,25 @@ def test_simple_markers_unchanged_by_compound_patterns():
         "•",
     ]
     assert [item.enumerated for item in items] == [True] * 9 + [False]
+
+
+def test_multiline_item_text_is_not_truncated():
+    """A list item that spans several lines keeps all of its text, not just line one."""
+    doc = DoclingDocument(name="Multiline items")
+    group = doc.add_list_group(name="list")
+    raws = [
+        "[15] Author, Title, Journal\r\nvol. 436 (2012), 2963-2965.",
+        "1. First step of the procedure\r\ncontinued on the next line.",
+        "• Layerwise quantization. Finds optimal weights\r\nthat minimize the loss.",
+    ]
+    for raw in raws:
+        doc.add_list_item(text=raw, parent=group)
+
+    ListItemMarkerProcessor().process_document(doc)
+
+    items = [item for item in doc.texts if isinstance(item, ListItem)]
+
+    assert [item.marker for item in items] == ["[15]", "1.", "•"]
+    # marker + the separating whitespace + text must account for the whole original.
+    for item in items:
+        assert item.orig == f"{item.marker} {item.text}"


### PR DESCRIPTION
Fixes #179.

### The bug

`ListItemMarkerProcessor` compiles its item patterns as `^(marker)\s(.+)` **without `re.DOTALL`**, so the content group stops at the first newline:

```python
self._compiled_bullet_item_patterns = [
    re.compile(f"^({pattern})" + r"\s(.+)") for pattern in self._bullet_patterns
]
```

`item.orig` keeps the full string and nothing is raised, so the loss is silent — but every consumer reading `item.text`, the serializers included, sees a truncated item.

Reproduced on `main` (`313d079`):

| case | marker | chars lost | resulting `.text` |
|---|---|---:|---|
| `[15] Author, Title, Journal\r\nvol. 436 (2012), 2963-2965.` | `[15]` | 28 | `'Author, Title, Journal\r'` |
| `1. First step of the procedure\r\ncontinued on the next line.` | `1.` | 28 | `'First step of the procedure\r'` |
| `• Layerwise quantization. Finds optimal weights\r\nthat minimize the loss.` | `•` | 24 | `'Layerwise quantization. Finds optimal weights\r'` |

The newline is not synthetic — as the issue notes, `PyPdfiumDocumentBackend` emits `\r\n` inside a single item's text where super/subscripts break the baseline, and `PageAssembleModel.sanitize_text()` joins those cells verbatim. Bibliography entries and wrapped list steps are the common victims.

### The fix

Compile the two `*_item_patterns` lists with `re.DOTALL`.

**Why this is narrow rather than a behavior change:**

- `re.DOTALL` only affects `.`. The marker patterns themselves contain no unescaped `.` (every literal dot is `\.`, and the ones inside character classes are unaffected), so the flag widens **only** the `(.+)` content group.
- The marker-only patterns (`^{pattern}$`, used by `_is_bullet_marker` / `_is_numbered_marker`) are left alone.
- `\s` already matched newlines regardless of the flag, so the marker/content separator behaves exactly as before.
- `process_list_item` and `process_text_item` share these compiled patterns, so the single change covers both call sites — no duplicated logic.

I deliberately did **not** normalise the retained newlines to spaces. As the reporter says, that is a separate decision about how list items should render downstream, and folding it in here would make this a behavior change rather than a truncation fix.

### Verification

Added `test_multiline_item_text_is_not_truncated` to `tests/test_listitem_marker_model.py`. It asserts the invariant directly — `item.orig == f"{item.marker} {item.text}"` — for a numbered, a dotted-numbered and a bullet item, each spanning two lines.

```
# before (src reverted, test applied)
1 failed, 3 passed

# after
4 passed
```

Also green together with the neighbouring suites:

```
$ python -m pytest tests/test_listitem_marker_model.py tests/test_reading_order.py tests/test_common.py -q
9 passed, 2 warnings in 32.18s
```

`black --check` on the touched module is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
