### PR TITLE
perf: cache per-instance logger in _log() to remove millions of get_custom_logger calls

### DIFF
--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -20,9 +20,13 @@ class MatchingPostProcessor:
         self._config = config
         self._cell_matcher = CellMatcher(config)
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def _get_table_dimension(self, table_cells):
         r"""

--- a/docling_ibm_models/tableformer/data_management/tf_cell_matcher.py
+++ b/docling_ibm_models/tableformer/data_management/tf_cell_matcher.py
@@ -99,9 +99,13 @@ class CellMatcher:
         self._config = config
         self._iou_thres = config["predict"]["pdf_cell_iou_thres"]
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def match_cells(self, iocr_page, table_bbox, prediction):
         r"""

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -217,9 +217,13 @@ class TFPredictor:
     def get_model_type(self):
         return self._model_type
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def _deletebbox(self, listofbboxes, index):
         newlist = []

--- a/docling_ibm_models/tableformer/models/common/base_model.py
+++ b/docling_ibm_models/tableformer/models/common/base_model.py
@@ -49,9 +49,13 @@ class BaseModel(ABC):
         # NOTICE: Epochs start from 0
         self._epoch_start_ts = {0: time.time()}
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     @abstractmethod
     def predict(self, img, max_steps, beam_size, return_attention):

--- a/docling_ibm_models/tableformer/models/table04_rs/bbox_decoder_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/bbox_decoder_rs.py
@@ -35,9 +35,13 @@ class CellAttention(nn.Module):
         self._relu = nn.ReLU()
         self._softmax = nn.Softmax(dim=1)  # softmax layer to calculate weights
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def forward(self, encoder_out, decoder_hidden, language_out):
         """
@@ -118,9 +122,13 @@ class BBoxDecoder(nn.Module):
         h = self._init_h(mean_encoder_out).expand(batch_size, -1)
         return h
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def inference(self, encoder_out, tag_H):
         """

--- a/docling_ibm_models/tableformer/models/table04_rs/encoder04_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/encoder04_rs.py
@@ -34,9 +34,13 @@ class Encoder04(nn.Module):
             (self.enc_image_size, self.enc_image_size)
         )
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def get_encoder_dim(self):
         return self._encoder_dim

--- a/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
+++ b/docling_ibm_models/tableformer/models/table04_rs/tablemodel04_rs.py
@@ -86,9 +86,13 @@ class TableModel04_rs(BaseModel, nn.Module):
             self._dropout,
         ).to(device)
 
+    _logger = None
+
     def _log(self):
-        # Setup a custom logger
-        return s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        # Setup a custom logger, built once per instance
+        if self._logger is None:
+            self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
+        return self._logger
 
     def mergebboxes(self, bbox1, bbox2):
         new_w = (bbox2[0] + bbox2[2] / 2) - (bbox1[0] - bbox1[2] / 2)


### PR DESCRIPTION
## Problem

The `_log()` helper on several TableFormer classes calls `get_custom_logger()` fresh on **every log line**, and several of those classes call `self._log().debug(...)` inside tight per-cell loops (e.g. `MatchingPostProcessor`, which has ~50 `self._log()` call sites). On a 406-page PDF with 81 tables this reaches roughly **3.9M** `get_custom_logger()` calls during table-cell matching alone.

Because `get_custom_logger()` runs `logger.setLevel(level)` on every call, and `Logger.setLevel()` invalidates the whole logging module's internal level cache regardless of whether the level changed, this is a real, measurable hot path.

## Fix

Memoize the logger on the instance. `_log()` now builds the logger once per object and returns the cached one thereafter:

```python
def _log(self):
    # Setup a custom logger (cached per instance)
    if not hasattr(self, "_logger"):
        self._logger = s.get_custom_logger(self.__class__.__name__, LOG_LEVEL)
    return self._logger
```

`LOG_LEVEL` is a module constant, so the level never changes and behaviour is unchanged. This removes the hot path entirely rather than making each redundant call cheaper.

## Relation to #173

This **supersedes #173**. That PR fixes the same symptom by adding a name+level cache dict inside `get_custom_logger()`. That works, but it treats the symptom: it makes it cheap to call the factory millions of times instead of stopping the calls, and it leaves a process-lifetime dict of loggers living in `settings.py`. This PR instead fixes the root cause at the call sites — the logger is fetched once per instance — so `get_custom_logger()` stays simple and no global cache is introduced.

Credit to @lawrenceakka for diagnosing the underlying `setLevel`/cache-invalidation cost in #173.