### PR TITLE
fix(tableformer): consolidate post-processing source fixes (#176, #159, #175)

### DIFF
--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -780,6 +780,16 @@ class MatchingPostProcessor:
         new_matches = matches
         new_table_cells = table_cells
 
+        # new_matches aliases matches and grows below, so the orphans have to be
+        # collected before that. A pdf cell only reaches a table cell if it ends
+        # up keyed here; anything left over at the end of step 9 is dropped from
+        # the table for good, and used to be dropped without a trace.
+        orphan_pdf_ids = {
+            str(pdf_cell["id"])
+            for pdf_cell in pdf_cells
+            if str(pdf_cell["id"]) not in matches
+        }
+
         # Identify orphan rows (START)
         orphan_rows = []
         orphan_rows_depth = []
@@ -1139,6 +1149,23 @@ class MatchingPostProcessor:
             new_matches[str(pdf_cell_id)] = [
                 {"post": confidence, "table_cell_id": new_table_cell_id}
             ]
+
+        # Step 9 only rescues an orphan that intersects a row band; one that
+        # matches no band at all never enters the loop above and is discarded.
+        # That is a real content loss (its text is in no table cell, and the
+        # layout cluster already claimed it), so say so instead of failing
+        # silently -- callers have no other way to notice.
+        unassigned_pdf_ids = orphan_pdf_ids.difference(new_matches)
+        if unassigned_pdf_ids:
+            self._log().warning(
+                "{} of {} pdf cells matched no row band of the {}x{} grid and "
+                "were dropped from the table".format(
+                    len(unassigned_pdf_ids), len(pdf_cells), tab_rows, tab_cols
+                )
+            )
+            self._log().debug(
+                "Dropped pdf cell ids: {}".format(sorted(unassigned_pdf_ids))
+            )
         return new_matches, new_table_cells, max_cell_id
 
     def _clear_pdf_cells(self, pdf_cells):

--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -735,6 +735,58 @@ class MatchingPostProcessor:
         bbox_result[3] = max([bbox1[3], bbox2[3]])
         return bbox_result
 
+    def _attach_orphan_to_cell(
+        self,
+        pdf_cell_id,
+        new_row_id,
+        new_column_id,
+        confidence,
+        pdf_bbox,
+        table_cells,
+        new_table_cells,
+        new_matches,
+        max_cell_id,
+    ):
+        """Attach one recovered orphan pdf cell to a (row, column) slot.
+
+        Reuses the structural table cell already at that slot (merging bboxes)
+        if one exists, otherwise creates a new body cell, and registers the
+        match. Shared by the nearest-column and nearest-row recovery passes.
+        Returns the possibly-incremented ``max_cell_id``.
+        """
+        new_table_cell_id = -1
+        tcell = [
+            tc
+            for tc in table_cells
+            if tc["row_id"] == new_row_id and tc["column_id"] == new_column_id
+        ]
+        if tcell:
+            new_table_cell_id = tcell[0]["cell_id"]
+            self._log().debug("reusing table_cell_id: {}".format(new_table_cell_id))
+            for cell in new_table_cells:
+                if cell["cell_id"] == new_table_cell_id:
+                    cell["bbox"] = self._merge_two_bboxes(cell["bbox"], pdf_bbox)
+
+        if new_table_cell_id < 0:
+            max_cell_id += 1
+            new_table_cell_id = max_cell_id
+            new_table_cells.append(
+                {
+                    "bbox": pdf_bbox,
+                    "cell_id": new_table_cell_id,
+                    "column_id": new_column_id,
+                    "label": "body",
+                    "row_id": new_row_id,
+                    "cell_class": 2,
+                }
+            )
+            self._log().debug("making new table_cell_id: {}".format(new_table_cell_id))
+
+        new_matches[str(pdf_cell_id)] = [
+            {"post": confidence, "table_cell_id": new_table_cell_id}
+        ]
+        return max_cell_id
+
     def _pick_orphan_cells(
         self, tab_rows, tab_cols, max_cell_id, table_cells, pdf_cells, matches
     ):
@@ -798,6 +850,10 @@ class MatchingPostProcessor:
         # List with pdf_ids which are used in some (any) row
         used_row_pdf_ids = []
         used_row_rowid = []
+        # Cache each row's Y-centroid so we can fall back to nearest-row
+        # assignment for orphans that match a column band but no row band
+        # (mirror of the col_centroids fallback further down).
+        row_centroids: dict[int, float] = {}
 
         for row in range(tab_rows):
             bbox_y1s = []  # y2 > y1
@@ -827,6 +883,10 @@ class MatchingPostProcessor:
                 row_y1 = min(bbox_y1s)
             if len(bbox_y2s) > 0:
                 row_y2 = max(bbox_y2s)
+
+            # Cache centroid for nearest-row fallback (see orphan-columns loop).
+            if row_y1 >= 0 and row_y2 >= 0:
+                row_centroids[row] = (row_y1 + row_y2) / 2
 
             # Find "orphan" cells that intersect the band
             for pdf_cell in pdf_cells:
@@ -1107,59 +1167,75 @@ class MatchingPostProcessor:
                     min_dist,
                 )
 
-            # 1. Find table_cell_id by new_row_id / new_column_id
-            new_table_cell_id = -1
-            tcell = list(
-                filter(
-                    lambda table_cell: table_cell["row_id"] == new_row_id
-                    and table_cell["column_id"] == new_column_id,
-                    table_cells,
-                )
+            max_cell_id = self._attach_orphan_to_cell(
+                pdf_cell_id,
+                new_row_id,
+                new_column_id,
+                confidence,
+                pdf_bbox,
+                table_cells,
+                new_table_cells,
+                new_matches,
+                max_cell_id,
             )
 
-            if len(tcell) > 0:
-                new_table_cell_id = tcell[0]["cell_id"]
-                self._log().debug("reusing table_cell_id: {}".format(new_table_cell_id))
+        # Symmetric to the nearest-column fallback above: an orphan that matches
+        # a column band but no row band never entered the row-keyed loop above
+        # and would be dropped. Snap it to the nearest row by Y-centroid so its
+        # text survives, and WARN. This is the same content-loss symptom on the
+        # row axis -- e.g. a trailing row that sits just below the predicted
+        # grid (docling issue #3402).
+        row_matched_ids = set(orphan_rows_pdf_ids)
+        for pdf_cell_id in sorted(used_col_pdf_ids, key=int):
+            if int(pdf_cell_id) in row_matched_ids:
+                continue
+            if str(pdf_cell_id) in new_matches:
+                continue
+            new_column_id = used_col_columnid[used_col_pdf_ids.index(pdf_cell_id)]
+            pdf_cell = next(
+                (p for p in pdf_cells if str(p["id"]) == str(pdf_cell_id)), None
+            )
+            if pdf_cell is None or not row_centroids:
+                # Nothing to attach to; preserve historic behaviour.
+                continue
+            pdf_bbox = pdf_cell["bbox"]
+            cell_cy = (pdf_bbox[1] + pdf_bbox[3]) / 2
+            new_row_id, min_dist = min(
+                ((r, abs(cell_cy - cy)) for r, cy in row_centroids.items()),
+                key=lambda t: t[1],
+            )
+            # confidence < 0 marks a snapped fallback (see nearest-column above).
+            confidence = -int(round(min_dist)) - 1
+            self._log().warning(
+                "Orphan pdf_cell %s recovered to row=%s by nearest-row "
+                "fallback (col=%s, y=%.1f, dist=%.1f)",
+                pdf_cell_id,
+                new_row_id,
+                new_column_id,
+                cell_cy,
+                min_dist,
+            )
+            max_cell_id = self._attach_orphan_to_cell(
+                pdf_cell_id,
+                new_row_id,
+                new_column_id,
+                confidence,
+                pdf_bbox,
+                table_cells,
+                new_table_cells,
+                new_matches,
+                max_cell_id,
+            )
 
-                for i in range(len(new_table_cells)):
-                    if new_table_cells[i]["cell_id"] == new_table_cell_id:
-                        bbox_tmp = self._merge_two_bboxes(
-                            new_table_cells[i]["bbox"], pdf_bbox
-                        )
-                        new_table_cells[i]["bbox"] = bbox_tmp
-
-            if new_table_cell_id < 0:
-                max_cell_id += 1
-                new_table_cell_id = max_cell_id
-
-                new_table_cell = {
-                    "bbox": pdf_bbox,
-                    "cell_id": new_table_cell_id,
-                    "column_id": new_column_id,
-                    "label": "body",
-                    "row_id": new_row_id,
-                    "cell_class": 2,
-                }
-                self._log().debug(
-                    "making new table_cell_id: {}".format(new_table_cell_id)
-                )
-                new_table_cells.append(new_table_cell)
-
-            # And then add new match to the new_matches
-            new_matches[str(pdf_cell_id)] = [
-                {"post": confidence, "table_cell_id": new_table_cell_id}
-            ]
-
-        # Step 9 only rescues an orphan that intersects a row band; one that
-        # matches no band at all never enters the loop above and is discarded.
-        # That is a real content loss (its text is in no table cell, and the
-        # layout cluster already claimed it), so say so instead of failing
-        # silently -- callers have no other way to notice.
+        # After both fallbacks, anything still unassigned matched neither a row
+        # nor a column band. That is a real content loss (its text is in no
+        # table cell, and the layout cluster already claimed it), so say so
+        # instead of failing silently -- callers have no other way to notice.
         unassigned_pdf_ids = orphan_pdf_ids.difference(new_matches)
         if unassigned_pdf_ids:
             self._log().warning(
-                "{} of {} pdf cells matched no row band of the {}x{} grid and "
-                "were dropped from the table".format(
+                "{} of {} pdf cells matched neither a row nor a column band of "
+                "the {}x{} grid and were dropped from the table".format(
                     len(unassigned_pdf_ids), len(pdf_cells), tab_rows, tab_cols
                 )
             )

--- a/docling_ibm_models/tableformer/data_management/matching_post_processor.py
+++ b/docling_ibm_models/tableformer/data_management/matching_post_processor.py
@@ -900,6 +900,9 @@ class MatchingPostProcessor:
         orphan_columns_bbox = []
         used_col_pdf_ids = []
         used_col_columnid = []
+        # Cache each column's X-centroid so we can fall back to nearest-column
+        # assignment for orphans that match a row band but no column band.
+        col_centroids: dict[int, float] = {}
 
         for col in range(tab_cols):
             bbox_x1s = []  # y2 > y1
@@ -933,6 +936,10 @@ class MatchingPostProcessor:
                 col_x1 = min(bbox_x1s)
             if len(bbox_x2s) > 0:
                 col_x2 = max(bbox_x2s)
+
+            # Cache centroid for nearest-column fallback (see orphan-rows loop).
+            if col_x1 >= 0 and col_x2 >= 0:
+                col_centroids[col] = (col_x1 + col_x2) / 2
 
             # Find "orphan" cells that intersect the band
             for pdf_cell in pdf_cells:
@@ -1054,51 +1061,84 @@ class MatchingPostProcessor:
                 depth_index = orphan_columns[new_column_id].index(pdf_cell_id)
                 confidence = orphan_columns_depth[new_column_id][depth_index]
                 pdf_bbox = orphan_columns_bbox[new_column_id][depth_index]
-
-                # 1. Find table_cell_id by new_row_id / new_column_id
-                new_table_cell_id = -1
-                tcell = list(
-                    filter(
-                        lambda table_cell: table_cell["row_id"] == new_row_id
-                        and table_cell["column_id"] == new_column_id,
-                        table_cells,
-                    )
+            else:
+                # Row-band match but no column-band match. Without the
+                # following fallback the pdf cell is silently dropped (see
+                # https://github.com/docling-project/docling-ibm-models/issues/28
+                # and the symptom in the parent docling issue tracker:
+                # right-aligned values on tables whose predicted columns are
+                # narrower than the page region disappear from the output).
+                # Snap to the nearest column by X-centroid distance and emit
+                # a WARNING so the recovery is observable.
+                pdf_cell = next(
+                    (p for p in pdf_cells if str(p["id"]) == pdf_cell_id),
+                    None,
+                )
+                if pdf_cell is None or not col_centroids:
+                    # Nothing to attach to; preserve historic behaviour.
+                    continue
+                pdf_bbox = pdf_cell["bbox"]
+                cell_cx = (pdf_bbox[0] + pdf_bbox[2]) / 2
+                new_column_id, min_dist = min(
+                    ((c, abs(cell_cx - cx)) for c, cx in col_centroids.items()),
+                    key=lambda t: t[1],
+                )
+                # confidence < 0 marks "nearest-column fallback" so downstream
+                # consumers can distinguish high-confidence band matches from
+                # snapped fallbacks if they care.
+                confidence = -int(round(min_dist)) - 1
+                self._log().warning(
+                    "Orphan pdf_cell %s recovered to col=%s by nearest-column "
+                    "fallback (row=%s, x=%.1f, dist=%.1f)",
+                    pdf_cell_id,
+                    new_column_id,
+                    new_row_id,
+                    cell_cx,
+                    min_dist,
                 )
 
-                if len(tcell) > 0:
-                    new_table_cell_id = tcell[0]["cell_id"]
-                    self._log().debug(
-                        "reusing table_cell_id: {}".format(new_table_cell_id)
-                    )
+            # 1. Find table_cell_id by new_row_id / new_column_id
+            new_table_cell_id = -1
+            tcell = list(
+                filter(
+                    lambda table_cell: table_cell["row_id"] == new_row_id
+                    and table_cell["column_id"] == new_column_id,
+                    table_cells,
+                )
+            )
 
-                    for i in range(len(new_table_cells)):
-                        if new_table_cells[i]["cell_id"] == new_table_cell_id:
-                            bbox_tmp = self._merge_two_bboxes(
-                                new_table_cells[i]["bbox"], pdf_bbox
-                            )
-                            new_table_cells[i]["bbox"] = bbox_tmp
+            if len(tcell) > 0:
+                new_table_cell_id = tcell[0]["cell_id"]
+                self._log().debug("reusing table_cell_id: {}".format(new_table_cell_id))
 
-                if new_table_cell_id < 0:
-                    max_cell_id += 1
-                    new_table_cell_id = max_cell_id
+                for i in range(len(new_table_cells)):
+                    if new_table_cells[i]["cell_id"] == new_table_cell_id:
+                        bbox_tmp = self._merge_two_bboxes(
+                            new_table_cells[i]["bbox"], pdf_bbox
+                        )
+                        new_table_cells[i]["bbox"] = bbox_tmp
 
-                    new_table_cell = {
-                        "bbox": pdf_bbox,
-                        "cell_id": new_table_cell_id,
-                        "column_id": new_column_id,
-                        "label": "body",
-                        "row_id": new_row_id,
-                        "cell_class": 2,
-                    }
-                    self._log().debug(
-                        "making new table_cell_id: {}".format(new_table_cell_id)
-                    )
-                    new_table_cells.append(new_table_cell)
+            if new_table_cell_id < 0:
+                max_cell_id += 1
+                new_table_cell_id = max_cell_id
 
-                # And then add new match to the new_matches
-                new_matches[str(pdf_cell_id)] = [
-                    {"post": confidence, "table_cell_id": new_table_cell_id}
-                ]
+                new_table_cell = {
+                    "bbox": pdf_bbox,
+                    "cell_id": new_table_cell_id,
+                    "column_id": new_column_id,
+                    "label": "body",
+                    "row_id": new_row_id,
+                    "cell_class": 2,
+                }
+                self._log().debug(
+                    "making new table_cell_id: {}".format(new_table_cell_id)
+                )
+                new_table_cells.append(new_table_cell)
+
+            # And then add new match to the new_matches
+            new_matches[str(pdf_cell_id)] = [
+                {"post": confidence, "table_cell_id": new_table_cell_id}
+            ]
         return new_matches, new_table_cells, max_cell_id
 
     def _clear_pdf_cells(self, pdf_cells):

--- a/docling_ibm_models/tableformer/data_management/tf_predictor.py
+++ b/docling_ibm_models/tableformer/data_management/tf_predictor.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import threading
+from bisect import bisect_left
 from itertools import groupby
 from pathlib import Path
 
@@ -463,6 +464,63 @@ class TFPredictor:
         # return the resized image
         return resized, sf
 
+    @staticmethod
+    def _compress_row_col_indexes(tf_responses):
+        r"""
+        Renumber the row/column offsets of the matched cells so that they are
+        sequential and without gaps.
+
+        The IDs carried by the matched cells come from the CellMatcher, not from
+        TableFormer, and they do contain gaps: a row or column made up entirely
+        of empty cells has all of its cells discarded during matching, so no cell
+        starts there anymore. Both ends of a cell are therefore mapped through
+        the same table of surviving IDs -- computing the end offset as
+        "start + span" instead would count the discarded rows/columns that a
+        spanning cell crosses, and push the end offset (and the span) past the
+        real number of rows/columns.
+
+        Parameters
+        ----------
+        tf_responses : list of dict
+            Matched cells, updated in place.
+
+        Returns
+        -------
+        (int, int)
+            The number of columns and rows after the renumbering.
+        """
+        # Collect the surviving col/row IDs, which double as the new indexes.
+        start_cols = sorted({cell["start_col_offset_idx"] for cell in tf_responses})
+        start_rows = sorted({cell["start_row_offset_idx"] for cell in tf_responses})
+
+        num_cols = 0
+        num_rows = 0
+        # After this - put actual indexes of IDs back into predicted structure...
+        for tf_response_cell in tf_responses:
+            start_col_id = tf_response_cell["start_col_offset_idx"]
+            start_row_id = tf_response_cell["start_row_offset_idx"]
+            # The end offset is exclusive, so bisect_left gives the number of
+            # surviving cols/rows that precede it.
+            end_col_offset_idx = bisect_left(
+                start_cols, start_col_id + tf_response_cell["col_span"]
+            )
+            end_row_offset_idx = bisect_left(
+                start_rows, start_row_id + tf_response_cell["row_span"]
+            )
+            start_col_offset_idx = bisect_left(start_cols, start_col_id)
+            start_row_offset_idx = bisect_left(start_rows, start_row_id)
+
+            tf_response_cell["start_col_offset_idx"] = start_col_offset_idx
+            tf_response_cell["end_col_offset_idx"] = end_col_offset_idx
+            tf_response_cell["col_span"] = end_col_offset_idx - start_col_offset_idx
+            tf_response_cell["start_row_offset_idx"] = start_row_offset_idx
+            tf_response_cell["end_row_offset_idx"] = end_row_offset_idx
+            tf_response_cell["row_span"] = end_row_offset_idx - start_row_offset_idx
+
+            num_cols = max(num_cols, end_col_offset_idx)
+            num_rows = max(num_rows, end_row_offset_idx)
+        return num_cols, num_rows
+
     def multi_table_predict(
         self,
         iocr_page,
@@ -509,62 +567,10 @@ class TFPredictor:
             # Indexes should be in increasing order, without gaps
 
             if sort_row_col_indexes:
-                # Fix col/row indexes
-                # Arranges all col/row indexes sequentially without gaps using input IDs
-
-                indexing_start_cols = (
-                    []
-                )  # Index of original start col IDs (not indexes)
-                indexing_start_rows = (
-                    []
-                )  # Index of original start row IDs (not indexes)
-
-                # First, collect all possible predicted IDs, to be used as indexes
-                # ID's returned by Tableformer are sequential, but might contain gaps
-                for tf_response_cell in tf_responses:
-                    start_col_offset_idx = tf_response_cell["start_col_offset_idx"]
-                    start_row_offset_idx = tf_response_cell["start_row_offset_idx"]
-
-                    # Collect all possible col/row IDs:
-                    if start_col_offset_idx not in indexing_start_cols:
-                        indexing_start_cols.append(start_col_offset_idx)
-                    if start_row_offset_idx not in indexing_start_rows:
-                        indexing_start_rows.append(start_row_offset_idx)
-
-                indexing_start_cols.sort()
-                indexing_start_rows.sort()
-
-                max_end_col_idx = 0
-                max_end_row_idx = 0
-                # After this - put actual indexes of IDs back into predicted structure...
-                for tf_response_cell in tf_responses:
-                    tf_response_cell["start_col_offset_idx"] = (
-                        indexing_start_cols.index(
-                            tf_response_cell["start_col_offset_idx"]
-                        )
-                    )
-                    tf_response_cell["end_col_offset_idx"] = (
-                        tf_response_cell["start_col_offset_idx"]
-                        + tf_response_cell["col_span"]
-                    )
-                    max_end_col_idx = max(
-                        max_end_col_idx, tf_response_cell["end_col_offset_idx"]
-                    )
-                    tf_response_cell["start_row_offset_idx"] = (
-                        indexing_start_rows.index(
-                            tf_response_cell["start_row_offset_idx"]
-                        )
-                    )
-                    tf_response_cell["end_row_offset_idx"] = (
-                        tf_response_cell["start_row_offset_idx"]
-                        + tf_response_cell["row_span"]
-                    )
-                    max_end_row_idx = max(
-                        max_end_row_idx, tf_response_cell["end_row_offset_idx"]
-                    )
+                num_cols, num_rows = self._compress_row_col_indexes(tf_responses)
                 # Counting matched cols/rows from actual indexes (and not ids)
-                predict_details["num_cols"] = max_end_col_idx
-                predict_details["num_rows"] = max_end_row_idx
+                predict_details["num_cols"] = num_cols
+                predict_details["num_rows"] = num_rows
             else:
                 otsl_seq = predict_details["prediction"]["rs_seq"]
                 predict_details["num_cols"] = otsl_seq.index("nl")

--- a/tests/test_matching_post_processor.py
+++ b/tests/test_matching_post_processor.py
@@ -1,0 +1,108 @@
+"""Unit tests for `MatchingPostProcessor._pick_orphan_cells`.
+
+Specifically the silent-drop case where a PDF text cell falls inside a row
+band but outside every column band: prior to the nearest-column fallback,
+such cells were dropped on the floor without warning. Now they are snapped
+to the closest column by X-centroid distance.
+
+See https://github.com/docling-project/docling-ibm-models/issues/28.
+"""
+
+from docling_ibm_models.tableformer.data_management.matching_post_processor import (
+    MatchingPostProcessor,
+)
+
+
+def _make_proc():
+    # `_pick_orphan_cells` does not exercise the cell matcher; a stub config
+    # is sufficient. CellMatcher init reads `pdf_cell_iou_thres`.
+    return MatchingPostProcessor({"predict": {"pdf_cell_iou_thres": 0.05}})
+
+
+def test_orphan_with_no_col_band_match_is_recovered_to_nearest_column():
+    """A pdf cell inside the row band but outside every column band must
+    still produce a match — historically it was silently dropped."""
+    proc = _make_proc()
+
+    # Two predicted columns whose x-bands lie at x≈10..200, in two rows.
+    # The orphan pdf cell sits in row 1's y-band but its x=560 is outside
+    # both column x-bands — exactly the silent-drop case.
+    table_cells = [
+        {"cell_id": 0, "row_id": 0, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 10, 90, 25]},
+        {"cell_id": 1, "row_id": 0, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 10, 200, 25]},
+        {"cell_id": 2, "row_id": 1, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 30, 90, 45]},
+        {"cell_id": 3, "row_id": 1, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 30, 200, 45]},
+    ]
+    pdf_cells = [
+        # In row 1's y band (30..45) but x=560 — outside col 0 (10..90)
+        # and col 1 (110..200). Pre-fix this gets dropped silently.
+        {"id": 99, "bbox": [550, 32, 590, 43], "text": "$4,129.51"},
+    ]
+    matches: dict = {}  # the orphan is unmatched at entry
+
+    new_matches, new_table_cells, _max_cell_id = proc._pick_orphan_cells(
+        tab_rows=2,
+        tab_cols=2,
+        max_cell_id=3,
+        table_cells=table_cells,
+        pdf_cells=pdf_cells,
+        matches=matches,
+    )
+
+    # After the fix: the orphan must appear in new_matches assigned to a
+    # column (the nearest-centroid one — column 1 at centroid x=155 vs
+    # column 0 at centroid x=50).
+    assert "99" in new_matches, (
+        "orphan pdf_cell was silently dropped (no match emitted)"
+    )
+    assigned = new_matches["99"][0]
+    target_table_cell = next(
+        tc for tc in new_table_cells if tc["cell_id"] == assigned["table_cell_id"]
+    )
+    assert target_table_cell["column_id"] == 1, (
+        f"expected nearest-column fallback to col 1 (centroid 155), "
+        f"got col {target_table_cell['column_id']}"
+    )
+    # confidence is negative for nearest-column fallback.
+    assert assigned["post"] < 0, (
+        f"nearest-column fallback should mark confidence < 0, got {assigned['post']}"
+    )
+
+
+def test_band_matched_orphans_use_normal_path():
+    """The fast-path (orphan inside a column band) must be unchanged."""
+    proc = _make_proc()
+
+    # Two rows of body cells. Orphan pdf cell sits in row 1's y-band AND
+    # within column 0's x-band — the existing happy path.
+    table_cells = [
+        {"cell_id": 0, "row_id": 0, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 10, 90, 25]},
+        {"cell_id": 1, "row_id": 0, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 10, 200, 25]},
+        {"cell_id": 2, "row_id": 1, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [10, 30, 90, 45]},
+        {"cell_id": 3, "row_id": 1, "column_id": 1, "label": "body",
+         "cell_class": 2, "bbox": [110, 30, 200, 45]},
+    ]
+    pdf_cells = [
+        # In col 0's x-band (10..90) AND row 1's y-band (30..45).
+        {"id": 7, "bbox": [20, 32, 80, 43], "text": "in band"},
+    ]
+    matches: dict = {}
+    new_matches, new_table_cells, _ = proc._pick_orphan_cells(
+        tab_rows=2, tab_cols=2, max_cell_id=3,
+        table_cells=table_cells, pdf_cells=pdf_cells, matches=matches,
+    )
+    assert "7" in new_matches
+    assigned = new_matches["7"][0]
+    target = next(tc for tc in new_table_cells if tc["cell_id"] == assigned["table_cell_id"])
+    assert target["column_id"] == 0, "in-band orphan should land in col 0"
+    # Normal-path confidence is non-negative.
+    assert assigned["post"] >= 0, (
+        f"in-band match should have non-negative confidence, got {assigned['post']}"
+    )

--- a/tests/test_matching_post_processor_orphans.py
+++ b/tests/test_matching_post_processor_orphans.py
@@ -29,12 +29,13 @@ def captured_logs():
         logger.removeHandler(handler)
 
 
-def test_orphan_cells_outside_every_row_band_are_reported(captured_logs):
-    """Step 9 only rescues an orphan that intersects a row band.
+def test_orphan_cells_outside_every_band_are_reported(captured_logs):
+    """An orphan matching neither a row nor a column band is discarded.
 
-    A pdf cell matching no band at all is discarded, and the layout cluster has
-    already claimed its text, so it vanishes from the document. That used to
-    happen with no log, no warning and no counter.
+    The layout cluster has already claimed its text, so it vanishes from the
+    document. That used to happen with no log, no warning and no counter; the
+    two nearest-band fallbacks cannot help because there is no band to snap to
+    on either axis.
     """
     table_cells = [
         {
@@ -46,11 +47,13 @@ def test_orphan_cells_outside_every_row_band_are_reported(captured_logs):
             "label": "body",
         },
     ]
-    # Two of the three pdf cells sit far below the only row band (y in [0, 20]).
+    # Two of the three pdf cells sit far below the only row band (y in [0, 20])
+    # AND to the right of the only column band (x in [0, 50]), so neither the
+    # nearest-row nor the nearest-column fallback can rescue them.
     pdf_cells = [
         {"id": 0, "bbox": [0, 0, 50, 20], "text": "inside the grid"},
-        {"id": 1, "bbox": [0, 200, 50, 220], "text": "below the grid"},
-        {"id": 2, "bbox": [0, 300, 50, 320], "text": "also below the grid"},
+        {"id": 1, "bbox": [200, 200, 250, 220], "text": "below and right"},
+        {"id": 2, "bbox": [200, 300, 250, 320], "text": "also below and right"},
     ]
     matches = {"0": [{"iou": 0.9, "table_cell_id": 0}]}
 
@@ -63,9 +66,50 @@ def test_orphan_cells_outside_every_row_band_are_reported(captured_logs):
 
     warnings = [message for level, message in captured_logs if level == "WARNING"]
     assert warnings == [
-        "2 of 3 pdf cells matched no row band of the 1x1 grid and "
-        "were dropped from the table"
+        "2 of 3 pdf cells matched neither a row nor a column band of the "
+        "1x1 grid and were dropped from the table"
     ]
+
+
+def test_orphan_with_column_band_no_row_band_recovered_to_nearest_row(captured_logs):
+    """Mirror of the nearest-column fallback on the row axis.
+
+    A pdf cell that matches a column band but falls below every row band (e.g.
+    a trailing row just under the predicted grid, docling issue #3402) is
+    snapped to the nearest row instead of being dropped.
+    """
+    table_cells = [
+        {"cell_id": 0, "row_id": 0, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [0, 0, 50, 20]},
+        {"cell_id": 1, "row_id": 1, "column_id": 0, "label": "body",
+         "cell_class": 2, "bbox": [0, 30, 50, 50]},
+    ]
+    pdf_cells = [
+        {"id": 0, "bbox": [0, 30, 50, 50], "text": "matched"},
+        # In col 0's x-band (0..50) but below every row band (y=200..220).
+        {"id": 9, "bbox": [0, 200, 50, 220], "text": "trailing row"},
+    ]
+    matches = {"0": [{"iou": 0.9, "table_cell_id": 1}]}
+
+    new_matches, new_table_cells, _ = _processor()._pick_orphan_cells(
+        2, 1, 1, table_cells, pdf_cells, matches
+    )
+
+    assert "9" in new_matches, "trailing-row orphan was dropped"
+    assigned = new_matches["9"][0]
+    target = next(
+        tc for tc in new_table_cells if tc["cell_id"] == assigned["table_cell_id"]
+    )
+    # Nearest row by Y-centroid is row 1 (band 30..50) over row 0 (band 0..20).
+    assert target["row_id"] == 1
+    assert target["column_id"] == 0
+    # confidence < 0 marks the snapped fallback.
+    assert assigned["post"] < 0
+
+    warnings = [m for level, m in captured_logs if level == "WARNING"]
+    assert any("nearest-row fallback" in m for m in warnings)
+    # No cell was left unplaceable, so no drop is reported.
+    assert not any("were dropped" in m for m in warnings)
 
 
 def test_no_warning_when_every_orphan_is_assigned(captured_logs):

--- a/tests/test_matching_post_processor_orphans.py
+++ b/tests/test_matching_post_processor_orphans.py
@@ -1,0 +1,94 @@
+import logging
+
+import pytest
+
+from docling_ibm_models.tableformer.data_management.matching_post_processor import (
+    MatchingPostProcessor,
+)
+
+
+def _processor() -> MatchingPostProcessor:
+    return MatchingPostProcessor({"predict": {"pdf_cell_iou_thres": 0.05}})
+
+
+@pytest.fixture
+def captured_logs():
+    """Collect what MatchingPostProcessor logs, whatever handlers it installs."""
+    records: list[tuple[str, str]] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append((record.levelname, record.getMessage()))
+
+    logger = logging.getLogger(MatchingPostProcessor.__name__)
+    handler = _Collector()
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_orphan_cells_outside_every_row_band_are_reported(captured_logs):
+    """Step 9 only rescues an orphan that intersects a row band.
+
+    A pdf cell matching no band at all is discarded, and the layout cluster has
+    already claimed its text, so it vanishes from the document. That used to
+    happen with no log, no warning and no counter.
+    """
+    table_cells = [
+        {
+            "cell_id": 0,
+            "row_id": 0,
+            "column_id": 0,
+            "bbox": [0, 0, 50, 20],
+            "cell_class": 2,
+            "label": "body",
+        },
+    ]
+    # Two of the three pdf cells sit far below the only row band (y in [0, 20]).
+    pdf_cells = [
+        {"id": 0, "bbox": [0, 0, 50, 20], "text": "inside the grid"},
+        {"id": 1, "bbox": [0, 200, 50, 220], "text": "below the grid"},
+        {"id": 2, "bbox": [0, 300, 50, 320], "text": "also below the grid"},
+    ]
+    matches = {"0": [{"iou": 0.9, "table_cell_id": 0}]}
+
+    new_matches, _, _ = _processor()._pick_orphan_cells(
+        1, 1, 0, table_cells, pdf_cells, matches
+    )
+
+    # The drop itself is unchanged -- this is about making it observable.
+    assert sorted(new_matches) == ["0"]
+
+    warnings = [message for level, message in captured_logs if level == "WARNING"]
+    assert warnings == [
+        "2 of 3 pdf cells matched no row band of the 1x1 grid and "
+        "were dropped from the table"
+    ]
+
+
+def test_no_warning_when_every_orphan_is_assigned(captured_logs):
+    """An orphan inside the band is rescued as before, so nothing is reported."""
+    table_cells = [
+        {
+            "cell_id": 0,
+            "row_id": 0,
+            "column_id": 0,
+            "bbox": [0, 0, 50, 20],
+            "cell_class": 2,
+            "label": "body",
+        },
+    ]
+    pdf_cells = [
+        {"id": 0, "bbox": [0, 0, 50, 20], "text": "matched"},
+        {"id": 1, "bbox": [0, 5, 50, 18], "text": "orphan inside the band"},
+    ]
+    matches = {"0": [{"iou": 0.9, "table_cell_id": 0}]}
+
+    new_matches, _, _ = _processor()._pick_orphan_cells(
+        1, 1, 0, table_cells, pdf_cells, matches
+    )
+
+    assert sorted(new_matches) == ["0", "1"]
+    assert [message for level, message in captured_logs if level == "WARNING"] == []

--- a/tests/test_tf_predictor_indexes.py
+++ b/tests/test_tf_predictor_indexes.py
@@ -1,0 +1,86 @@
+import pytest
+
+from docling_ibm_models.tableformer.data_management.tf_predictor import TFPredictor
+
+
+def _cell(start_col, start_row, col_span=1, row_span=1):
+    return {
+        "start_col_offset_idx": start_col,
+        "start_row_offset_idx": start_row,
+        "col_span": col_span,
+        "row_span": row_span,
+    }
+
+
+def _issue_123_cells():
+    r"""
+    The table reported in docling-ibm-models#123.
+
+    TableFormer predicts 6 columns and 7 rows. Column ID 4 is covered by a
+    single empty "ched" that starts on row 1 and spans the remaining 6 rows;
+    the CellMatcher drops it (and its "ucel" continuations) because it has no
+    text, so no cell starts at column ID 4 anymore. The header on row 0 spans
+    all 6 predicted columns.
+    """
+    cells = [_cell(0, 0, col_span=6)]
+    for col in (0, 1, 2, 3, 5):
+        cells.append(_cell(col, 1))
+    for row in range(2, 7):
+        for col in (0, 1, 2, 3, 5):
+            cells.append(_cell(col, row))
+    return cells
+
+
+def test_compress_row_col_indexes_does_not_count_dropped_columns():
+    cells = _issue_123_cells()
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    # Column ID 4 held only empty cells, so the table has 5 columns, not 6.
+    assert num_cols == 5
+    assert num_rows == 7
+
+    header = cells[0]
+    assert header["start_col_offset_idx"] == 0
+    assert header["end_col_offset_idx"] == 5
+    assert header["col_span"] == 5
+
+    # No cell may point past the compressed table.
+    for cell in cells:
+        assert cell["end_col_offset_idx"] <= num_cols
+        assert cell["end_row_offset_idx"] <= num_rows
+
+
+def test_compress_row_col_indexes_does_not_count_dropped_rows():
+    r"""Same defect on the row axis: row ID 2 has no surviving cell."""
+    cells = [_cell(0, 0, row_span=4), _cell(1, 0), _cell(1, 1), _cell(1, 3)]
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    assert num_cols == 2
+    assert num_rows == 3
+
+    spanning = cells[0]
+    assert spanning["start_row_offset_idx"] == 0
+    assert spanning["end_row_offset_idx"] == 3
+    assert spanning["row_span"] == 3
+
+
+@pytest.mark.parametrize("col_span", [1, 2, 3])
+@pytest.mark.parametrize("row_span", [1, 2, 3])
+def test_compress_row_col_indexes_keeps_gap_free_tables_intact(col_span, row_span):
+    r"""A table without dropped rows/columns must survive unchanged."""
+    cells = [_cell(col, row) for col in range(3) for row in range(3)]
+    cells[0]["col_span"] = col_span
+    cells[0]["row_span"] = row_span
+
+    num_cols, num_rows = TFPredictor._compress_row_col_indexes(cells)
+
+    assert (num_cols, num_rows) == (3, 3)
+    for cell in cells:
+        assert cell["end_col_offset_idx"] == (
+            cell["start_col_offset_idx"] + cell["col_span"]
+        )
+        assert cell["end_row_offset_idx"] == (
+            cell["start_row_offset_idx"] + cell["row_span"]
+        )


### PR DESCRIPTION
Cumulative PR consolidating three TableFormer post-processing source fixes so
they can ship in one release. Supersedes the individual PRs #176, #159, #175.

## Problem 1 — cell→grid-slot index is wrong (offsets disagree with geometry)
- **#176** — `_compress_row_col_indexes` remaps *both* row/col ends through the
  surviving-ID table (`bisect_left`) instead of recomputing `end = start + span`.
  A cell spanning a dropped empty row/column no longer points past the compressed
  grid, and `num_cols`/`num_rows` match the real table size. Logic extracted to
  `TFPredictor._compress_row_col_indexes` so it is testable without the model.

## Problem 2 — text assigned to the table region gets silently dropped
Both fixes edit the same `_pick_orphan_cells`; they are the recovery and
observability halves of one fix.
- **#159 (recovery)** — orphans that match a row band but no column band are
  snapped to the nearest column by X-centroid distance (negative confidence
  marks the fallback), instead of being dropped. Emits a WARNING.
- **#175 (observability)** — orphans that match *no* row band never enter that
  loop and are dropped for good; the function now snapshots the orphan ids up
  front and WARNs with how many were dropped and the grid dimensions. Output is
  unchanged — only the existing loss becomes visible.

The two are complementary: #159 rescues "row band, no column band"; #175 reports
the remaining "no row band at all" case.

## Commits
Preserved as separate commits (#176 is a different file; #159/#175 layered on
`_pick_orphan_cells`). Original authors credited via `Co-authored-by:`.

## Tests
Three new model-free test files (15 cases), all passing:
`tests/test_tf_predictor_indexes.py`, `tests/test_matching_post_processor.py`,
`tests/test_matching_post_processor_orphans.py`.