### PR TITLE
fix: exclude broken transformers versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,7 @@ dependencies = [
   'Pillow (>=10.0.0,<13.0.0)',
   'huggingface_hub (>=0.23,<2)',
   'safetensors[torch] (>=0.4.3,<1)',
-  'transformers (>=4.42.0,<6.0.0) ; sys_platform == "darwin"',
-  # transformers 5.13.0 breaks AutoImageProcessor.register() with a string config_class
-  # (fixed upstream in huggingface/transformers#47148, shipped in 5.13.1); see #167
-  'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0) ; sys_platform != "darwin"',
+  'transformers (>=4.42.0,<6.0.0)',
   'numpy (>=1.24.4,<3.0.0)',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,7 @@ dependencies = [
   'Pillow (>=10.0.0,<13.0.0)',
   'huggingface_hub (>=0.23,<2)',
   'safetensors[torch] (>=0.4.3,<1)',
-  # transformers 5.9.0-5.15.x crash on Apple's MPS backend:
-  # build_2d_sinusoidal_position_embedding allocates float64 tensors on-device,
-  # which MPS cannot represent (RT-DETR, D-FINE, ViT-MAE and friends). Fixed in
-  # 5.16.0, so exclude that window on macOS rather than capping below it. The
-  # window also subsumes the 5.13.0 AutoImageProcessor.register() bug below.
-  'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.9.*,!=5.10.*,!=5.11.*,!=5.12.*,!=5.13.*,!=5.14.*,!=5.15.*) ; sys_platform == "darwin"',
+  'transformers (>=4.42.0,<6.0.0) ; sys_platform == "darwin"',
   # transformers 5.13.0 breaks AutoImageProcessor.register() with a string config_class
   # (fixed upstream in huggingface/transformers#47148, shipped in 5.13.1); see #167
   'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0) ; sys_platform != "darwin"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,12 @@ dependencies = [
   'Pillow (>=10.0.0,<13.0.0)',
   'huggingface_hub (>=0.23,<2)',
   'safetensors[torch] (>=0.4.3,<1)',
-  # temporary solution until huggingface/transformers#46159 is resolved
-  'transformers (>=4.42.0,<5.9.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*) ; sys_platform == "darwin"',
+  # transformers 5.9.0-5.15.x crash on Apple's MPS backend:
+  # build_2d_sinusoidal_position_embedding allocates float64 tensors on-device,
+  # which MPS cannot represent (RT-DETR, D-FINE, ViT-MAE and friends). Fixed in
+  # 5.16.0, so exclude that window on macOS rather than capping below it. The
+  # window also subsumes the 5.13.0 AutoImageProcessor.register() bug below.
+  'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.9.*,!=5.10.*,!=5.11.*,!=5.12.*,!=5.13.*,!=5.14.*,!=5.15.*) ; sys_platform == "darwin"',
   # transformers 5.13.0 breaks AutoImageProcessor.register() with a string config_class
   # (fixed upstream in huggingface/transformers#47148, shipped in 5.13.1); see #167
   'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0) ; sys_platform != "darwin"',

--- a/uv.lock
+++ b/uv.lock
@@ -593,8 +593,7 @@ requires-dist = [
     { name = "safetensors", extras = ["torch"], specifier = ">=0.4.3,<1" },
     { name = "torch", specifier = ">=2.2.2,<3.0.0" },
     { name = "torchvision", specifier = ">=0,<1" },
-    { name = "transformers", marker = "sys_platform != 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0,<6.0.0" },
-    { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,<6.0.0" },
+    { name = "transformers", specifier = ">=4.42.0,<6.0.0" },
 ]
 provides-extras = ["opencv-python-headless", "opencv-python"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.2.2,<3.0.0" },
     { name = "torchvision", specifier = ">=0,<1" },
     { name = "transformers", marker = "sys_platform != 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0,<6.0.0" },
-    { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.9.*,!=5.10.*,!=5.11.*,!=5.12.*,!=5.13.*,!=5.14.*,!=5.15.*,<6.0.0" },
+    { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,<6.0.0" },
 ]
 provides-extras = ["opencv-python-headless", "opencv-python"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.2.2,<3.0.0" },
     { name = "torchvision", specifier = ">=0,<1" },
     { name = "transformers", marker = "sys_platform != 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.13.0,<6.0.0" },
-    { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,<5.9.0" },
+    { name = "transformers", marker = "sys_platform == 'darwin'", specifier = ">=4.42.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.9.*,!=5.10.*,!=5.11.*,!=5.12.*,!=5.13.*,!=5.14.*,!=5.15.*,<6.0.0" },
 ]
 provides-extras = ["opencv-python-headless", "opencv-python"]
 


### PR DESCRIPTION
same reason as: https://github.com/docling-project/docling-core/pull/741